### PR TITLE
(IGNORE) Remove cargo-edit from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,11 +67,11 @@ jobs:
       with:
         toolchain: stable
 
-    - name: Install cargo-edit
-      run: cargo install cargo-edit
-
     - name: Bump crate versions
-      run: cargo set-version --workspace ${{ steps.set-version.outputs.version }}
+      run: |
+        sed -i "s/^version = \"[^\"]*\"$/version = \"$VERSION\"/;" Cargo.toml
+      env:
+        VERSION: ${{ steps.set-version.outputs.version }}
 
     - name: Report differences for "prepare (release)" commit
       run: git diff


### PR DESCRIPTION
## Changes in This Pull Request
Removing `cargo install cargo-edit` from the publish workflow should save us about five minutes.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
