### PR TITLE
Add --info option 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "c2pa"
-version = "0.12.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c73e98725f6c64dbe7225b81f1919bc57da7fe41d67458c4393386baf1c3f02"
+checksum = "a0c6f1d2a7795db0749c88395c8723dcba50626399811516fa064d77800dc56d"
 dependencies = [
  "atree",
  "base64",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,7 +317,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,12 @@ readme = "README.md"
 keywords = ["c2pa", "xmp", "metadata"]
 edition = "2018"
 rust-version = "1.61.0"
+homepage = "https://contentauthenticity.org"
+repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { version = "0.12.0",features = ["bmff", "fetch_remote_manifests", "file_io",  "xmp_write"]}
+c2pa = { version = "0.13.0",features = ["bmff", "fetch_remote_manifests", "file_io",  "xmp_write"]}
 env_logger = "0.9"
 log = "0.4" 
 serde = { version = "1.0", features = ["derive"] }
@@ -32,5 +34,5 @@ predicates = "2.1"
 
 [profile.release] 
 strip = true  # Automatically strip symbols from the binary. 
-opt-level = "z"  # Optimize for size. 
-lto = true # Link time optimization. 
+# opt-level = "z"  # Optimize for size. 
+lto = "thin" # Link time optimization. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,8 @@ tempfile = "3.3"
 [dev-dependencies]
 assert_cmd = "2.0"
 predicates = "2.1"
+
+[profile.release] 
+strip = true  # Automatically strip symbols from the binary. 
+opt-level = "z"  # Optimize for size. 
+lto = true # Link time optimization. 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,5 +34,5 @@ predicates = "2.1"
 
 [profile.release] 
 strip = true  # Automatically strip symbols from the binary. 
-# opt-level = "z"  # Optimize for size. 
+opt-level = 3
 lto = "thin" # Link time optimization. 

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ test-local:
 # Run this before pushing a PR to pre-validate
 test: check-format clippy test-local
 
+fmt: 
+	cargo +nightly fmt
+
 # Creates a folder wtih c2patool bin, samples and readme
 c2patool-package:
 	rm -rf target/c2patool*

--- a/README.md
+++ b/README.md
@@ -46,6 +46,17 @@ The `-d` or `--detailed` option will print a detailed report describing the inte
 c2patool sample/C.jpg -d
 ```
 
+### Detailed manifest report
+
+The `--info` option will print a high level report about any c2pa content in the file. 
+For a cloud manifest it will display the url to the manifest.
+For embedded manifests, the size of the manifest store and number of manifests will be displayed. It will also report if the manifest validated or any errors encountered in validation.
+
+
+```shell
+c2patool sample/C.jpg --info
+```
+
 ### Adding a manifest to a file
 
 To add C2PA data to a file, use the `-m` or `--manifest` option and provide a manifest definition JSON file as the argument. The tool generates a new manifest using the values given in the file.

--- a/src/info.rs
+++ b/src/info.rs
@@ -1,0 +1,76 @@
+// Copyright 2022 Adobe. All rights reserved.
+// This file is licensed to you under the Apache License,
+// Version 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+// or the MIT license (http://opensource.org/licenses/MIT),
+// at your option.
+// Unless required by applicable law or agreed to in writing,
+// this software is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR REPRESENTATIONS OF ANY KIND, either express or
+// implied. See the LICENSE-MIT and LICENSE-APACHE files for the
+// specific language governing permissions and limitations under
+// each license.
+
+use std::path::Path;
+
+use anyhow::Result;
+use c2pa::{IngredientOptions, ManifestStore};
+
+/// display additional C2PA information about the asset (not json formatted)
+pub fn info(path: &Path) -> Result<()> {
+    struct Options {}
+    impl IngredientOptions for Options {
+        fn thumbnail(&self, _path: &Path) -> Option<(String, Vec<u8>)> {
+            None
+        }
+    }
+    let ingredient = c2pa::Ingredient::from_file_with_options(path, &Options {})?;
+    println!("Information for {}", ingredient.title());
+    //println!("instanceID = {}", ingredient.instance_id());
+    if let Some(provenance) = ingredient.provenance() {
+        if !provenance.starts_with("self#jumbf=") {
+            println!("Cloud URL = {}", provenance);
+        } else {
+            println!("XMP provenance URI = {}", provenance);
+        }
+    }
+    if let Some(manifest_data) = ingredient.manifest_data() {
+        let file_size = std::fs::metadata(path).unwrap().len();
+        println!(
+            "C2PA manifest store size = {} ({:.2}% of {})",
+            manifest_data.len(),
+            file_size as f64 / manifest_data.len() as f64,
+            file_size
+        );
+        if let Some(validation_status) = ingredient.validation_status() {
+            println!("Validation issues:");
+            for status in validation_status {
+                println!("   {}", status.code());
+            }
+        } else {
+            println!("Validated");
+        }
+        let manifest_store = ManifestStore::from_bytes("c2pa", manifest_data.to_vec(), false)?;
+        match manifest_store.manifests().len() {
+            0 => println!("No embedded manifests"),
+            1 => println!("One manifest"),
+            n => println!("{} Manifests", n),
+        }
+    } else {
+        println!("No C2PA Manifests");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+pub mod tests {
+    #![allow(clippy::expect_used)]
+
+    use super::*;
+
+    #[test]
+    fn test_manifest_config() {
+        const SOURCE_PATH: &str = "tests/fixtures/C.jpg";
+
+        info(&std::path::PathBuf::from(SOURCE_PATH)).expect("info");
+    }
+}

--- a/src/info.rs
+++ b/src/info.rs
@@ -30,7 +30,7 @@ pub fn info(path: &Path) -> Result<()> {
         if !provenance.starts_with("self#jumbf=") {
             println!("Cloud URL = {}", provenance);
         } else {
-            println!("XMP provenance URI = {}", provenance);
+            println!("Provenance URI = {}", provenance);
         }
     }
     if let Some(manifest_data) = ingredient.manifest_data() {
@@ -38,7 +38,7 @@ pub fn info(path: &Path) -> Result<()> {
         println!(
             "C2PA manifest store size = {} ({:.2}% of {})",
             manifest_data.len(),
-            file_size as f64 / manifest_data.len() as f64,
+            (manifest_data.len() as f64 / file_size as f64) * 100f64,
             file_size
         );
         if let Some(validation_status) = ingredient.validation_status() {
@@ -53,7 +53,7 @@ pub fn info(path: &Path) -> Result<()> {
         match manifest_store.manifests().len() {
             0 => println!("No embedded manifests"),
             1 => println!("One manifest"),
-            n => println!("{} Manifests", n),
+            n => println!("{} manifests", n),
         }
     } else {
         println!("No C2PA Manifests");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,7 +40,7 @@ fn tool_not_found() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("test/file/notfound.jpg");
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("File not found"));
+        .stderr(predicate::str::contains("No such file "));
     Ok(())
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,7 +40,7 @@ fn tool_not_found() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("test/file/notfound.jpg");
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("No such file "));
+        .stderr(predicate::str::contains("os error"));
     Ok(())
 }
 


### PR DESCRIPTION
## Changes in this pull request
Adds a --info option to help with cloud manifests and determining embedded manifest size
Improves error reporting, more consistent
Updates c2pa sdk
## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
