### PR TITLE
Fetch remote manifests for --info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,9 +258,9 @@ checksum = "ec8a7b6a70fde80372154c65702f00a0f56f3e1c36abbc6c440484be248856db"
 
 [[package]]
 name = "c2pa"
-version = "0.13.0"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0c6f1d2a7795db0749c88395c8723dcba50626399811516fa064d77800dc56d"
+checksum = "c9f42af1b4a0c8d365d4bec40ebdc9555f980b0fd0478f0d299a462597204468"
 dependencies = [
  "atree",
  "base64",
@@ -302,7 +302,6 @@ dependencies = [
  "spki 0.6.0",
  "tempfile",
  "thiserror",
- "time 0.3.13",
  "twoway",
  "ureq",
  "url",
@@ -354,7 +353,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time 0.1.44",
+ "time",
  "wasm-bindgen",
  "winapi",
 ]
@@ -1237,15 +1236,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,16 +2003,6 @@ dependencies = [
  "libc",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi",
-]
-
-[[package]]
-name = "time"
-version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db76ff9fa4b1458b3c7f077f3ff9887394058460d21e634355b273aaf11eea45"
-dependencies = [
- "libc",
- "num_threads",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { version = "0.13.0",features = ["bmff", "fetch_remote_manifests", "file_io",  "xmp_write"]}
+c2pa = { version = "0.13.2",features = ["bmff", "fetch_remote_manifests", "file_io",  "xmp_write"]}
 env_logger = "0.9"
 log = "0.4" 
 serde = { version = "1.0", features = ["derive"] }

--- a/src/info.rs
+++ b/src/info.rs
@@ -25,14 +25,17 @@ pub fn info(path: &Path) -> Result<()> {
     }
     let ingredient = c2pa::Ingredient::from_file_with_options(path, &Options {})?;
     println!("Information for {}", ingredient.title());
+    let mut is_cloud_manifest = false;
     //println!("instanceID = {}", ingredient.instance_id());
     if let Some(provenance) = ingredient.provenance() {
-        if !provenance.starts_with("self#jumbf=") {
+        is_cloud_manifest = !provenance.starts_with("self#jumbf=");
+        if is_cloud_manifest {
             println!("Cloud URL = {}", provenance);
         } else {
             println!("Provenance URI = {}", provenance);
         }
     }
+
     if let Some(manifest_data) = ingredient.manifest_data() {
         let file_size = std::fs::metadata(path).unwrap().len();
         println!(
@@ -51,10 +54,12 @@ pub fn info(path: &Path) -> Result<()> {
         }
         let manifest_store = ManifestStore::from_bytes("c2pa", manifest_data.to_vec(), false)?;
         match manifest_store.manifests().len() {
-            0 => println!("No embedded manifests"),
+            0 => println!("No manifests"),
             1 => println!("One manifest"),
             n => println!("{} manifests", n),
         }
+    } else if is_cloud_manifest {
+        println!("Unable to fetch cloud manifest");
     } else {
         println!("No C2PA Manifests");
     }

--- a/src/info.rs
+++ b/src/info.rs
@@ -38,12 +38,20 @@ pub fn info(path: &Path) -> Result<()> {
 
     if let Some(manifest_data) = ingredient.manifest_data() {
         let file_size = std::fs::metadata(path).unwrap().len();
-        println!(
-            "C2PA manifest store size = {} ({:.2}% of {})",
-            manifest_data.len(),
-            (manifest_data.len() as f64 / file_size as f64) * 100f64,
-            file_size
-        );
+        if is_cloud_manifest {
+            println!(
+                "Remote manifest store size = {} (file size = {})",
+                manifest_data.len(),
+                file_size
+            );
+        } else {
+            println!(
+                "Manifest store size = {} ({:.2}% of {})",
+                manifest_data.len(),
+                (manifest_data.len() as f64 / file_size as f64) * 100f64,
+                file_size
+            );
+        }
         if let Some(validation_status) = ingredient.validation_status() {
             println!("Validation issues:");
             for status in validation_status {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -50,7 +50,7 @@ fn tool_not_found_info() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("test/file/notfound.jpg").arg("--info");
     cmd.assert()
         .failure()
-        .stderr(predicate::str::contains("not found"));
+        .stderr(predicate::str::contains("os error"));
     Ok(())
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -45,12 +45,32 @@ fn tool_not_found() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn tool_not_found_info() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("c2patool")?;
+    cmd.arg("test/file/notfound.jpg").arg("--info");
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("not found"));
+    Ok(())
+}
+
+#[test]
 fn tool_jpeg_no_report() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("c2patool")?;
     cmd.arg(fixture_path(TEST_IMAGE));
     cmd.assert()
         .failure()
         .stderr(predicate::str::contains("No claim found"));
+    Ok(())
+}
+
+#[test]
+fn tool_info() -> Result<(), Box<dyn std::error::Error>> {
+    let mut cmd = Command::cargo_bin("c2patool")?;
+    cmd.arg(fixture_path("C.jpg")).arg("--info");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Validated\nOne manifest"));
     Ok(())
 }
 


### PR DESCRIPTION
## Changes in this pull request
Now fetches remote manifests for --info
better message when remote manifest fetch fails

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
