### PR TITLE
Fix ingredient thumbnail filename collision using instance_id

### DIFF
--- a/src/fs_report.rs
+++ b/src/fs_report.rs
@@ -50,7 +50,7 @@ fn write_ingredient_thumbnails(ingredients: &[Ingredient], destination: &Path) -
         .iter()
         .filter_map(|i| {
             i.thumbnail().map(|(format, bytes)| {
-                let title = add_extension(i.title(), format);
+                let title = add_extension(i.instance_id(), format).replace(['/', ':'], "-");
                 (title, bytes)
             })
         })


### PR DESCRIPTION
## Changes in this pull request
_When generating a manifest report and writing the output to a directory, if two ingredients in a manifest have the same title, one of the thumbnail files will be missing.  Manifests from Photoshop often have duplicate ingredient titles.  Using the instance_id for the filename should fix this._

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
