### PR TITLE
Fix doc formatting 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ The tool will display the version installed. Compare the version number displaye
  | `wav`         | `audio/x-wav`                                       | 
  | `webp`        | `image/webp`                                        | 
  
- <sup>*</sup> Fragmented mp4 is not yet supported.
- 
+<sup>*</sup> Fragmented mp4 is not yet supported.
+
 ## Usage
 
 The tool's command-line syntax is:


### PR DESCRIPTION
## Changes in this pull request

The README rendered on the doc site at https://opensource.contentauthenticity.org/docs/c2patool/ has a trivial formatting issue with an extra space on the line preceding a header defeating markdown parsing.  I hate to open a PR for such a trivial change, but it looks bad and makes the doc hard to peruse.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
