### PR TITLE
(MINOR) Update to c2pa-rs 0.24.0 - revert to previous signing model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,6 +157,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+
+[[package]]
 name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -292,14 +298,14 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "c2pa"
-version = "0.23.1"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4768e9005421b4f649b28799e283c03c314cb5f8b7be2069bb043800300d22d5"
+checksum = "4301811aebee9a6bb48ce19313cf27fc7cbe21c08370f1a647a52f39d18e50bb"
 dependencies = [
  "asn1-rs",
  "async-trait",
  "atree",
- "base64",
+ "base64 0.21.2",
  "bcder",
  "blake3",
  "byteorder",
@@ -356,7 +362,7 @@ dependencies = [
 
 [[package]]
 name = "c2patool"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1551,7 +1557,7 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
 dependencies = [
- "base64",
+ "base64 0.13.1",
 ]
 
 [[package]]
@@ -1973,9 +1979,9 @@ dependencies = [
 
 [[package]]
 name = "serde-wasm-bindgen"
-version = "0.4.5"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3b4c031cd0d9014307d82b8abf653c0290fbdaeb4c02d00c63cf52f728628bf"
+checksum = "f3b143e2833c57ab9ad3ea280d21fd34e285a42837aeb0ee301f4f41890fa00e"
 dependencies = [
  "js-sys",
  "serde",
@@ -2394,7 +2400,7 @@ version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338b31dd1314f68f3aabf3ed57ab922df95ffcd902476ca7ba3c4ce7b908c46d"
 dependencies = [
- "base64",
+ "base64 0.13.1",
  "flate2",
  "log",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { version = "0.23.1", features = ["fetch_remote_manifests", "file_io",  "xmp_write"]}
+c2pa = { version = "0.24.0", features = ["fetch_remote_manifests", "file_io",  "xmp_write"]}
 clap = { version = "3.2", features = ["derive"] }
 env_logger = "0.9"
 log = "0.4" 

--- a/README.md
+++ b/README.md
@@ -281,6 +281,17 @@ This section gives a highlight of noteworthy changes
 
 Refer to the [CHANGELOG](https://github.com/contentauth/c2patool/blob/main/CHANGELOG.md) for detailed Git changes
 
+# 0.6.0
+* Validates 1.3 signatures but will not generate them.
+* Supports other 1.3 features such as actions v2 and ingredients v2
+* Supports adding claim_generator_info to a manifest.
+* icons for claim_generator_info can be added as resource references
+* the sdk will create v2 actions or ingredients if required, but defaults to v1
+# 0.5.4
+* This introduced a 1.3 required change in signature format that is not compatible with previous verify code.
+* We want to give some time for developers to integrate 1.3 validation before using 1.3 signatures
+* Please avoid using 0.5.4 and update to 0.6.0 which can validate the new format but does not create it.
+
 # 0.5.3
 * fix bug where ingredient thumbnails were not generated
 * an ingredient.json file or folder can now be passed on the command line --parent option.


### PR DESCRIPTION
## Changes in this pull request
c2patool 0.5.4 introduced a 1.3 spec signature change that is not compatible with older sdks.
This version can validate the new signatures but does not write them
We want to avoid creating the new signatures until there are more clients that can read them.

