### PR TITLE
Added missing "sample/" file prefix in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ c2patool sample/image.jpg -m sample/test.json -f -o signed_image.jpg
 Use the `--sidecar` / `-s` option to put the manifest in an external sidecar file in the same location as the output file. The manifest will have the same output filename but with a `.c2pa` extension. The tool will copy the output file but the original will be untouched.
 
 ```shell
-c2patool image.jpg -s -m sample/test.json -o signed_image.jpg
+c2patool sample/image.jpg -s -m sample/test.json -o signed_image.jpg
 ```
 ### Generating a remote manifest
 


### PR DESCRIPTION

## Changes in this pull request
Added missing "sample/" path prefix to the `image.jpg` file in the [Generating an external manifest](https://github.com/contentauth/c2patool?tab=readme-ov-file#generating-an-external-manifest) example.

## Checklist
- [X] This PR represents a single feature, fix, or change.
- [X] All applicable changes have been documented.
- [X] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
