### PR TITLE
Add better support for cargo-binstall

### DIFF
--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -14,109 +14,109 @@ jobs:
       new-tag: ${{ steps.set-version.outputs.version_tag }}
 
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        token: ${{ secrets.GH_ADMIN_COMMIT_TOKEN }}
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GH_ADMIN_COMMIT_TOKEN }}
 
-    - name: Get latest existing tag
-      uses: WyriHaximus/github-action-get-previous-tag@v1
-      id: get-latest-tag
+      - name: Get latest existing tag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        id: get-latest-tag
 
-    - name: Set new version
-      uses: paulhatch/semantic-version@v5.2.1
-      id: set-version
-      with:
-        tag_prefix: "v"
-        version_format: "${major}.${minor}.${patch}"
-        major_pattern: "(MAJOR)"
-        minor_pattern: "(MINOR)"
+      - name: Set new version
+        uses: paulhatch/semantic-version@v5.2.1
+        id: set-version
+        with:
+          tag_prefix: "v"
+          version_format: "${major}.${minor}.${patch}"
+          major_pattern: "(MAJOR)"
+          minor_pattern: "(MINOR)"
 
-    - name: Generate changelog since last tag
-      id: generate-changelog
-      run: |
-        {
-          echo 'changelog<<EOF'
-          git log --format="* %s" ${{ steps.get-latest-tag.outputs.tag }}..HEAD | { grep -v "(IGNORE)" || :; }
-          echo EOF
-        } >> "$GITHUB_OUTPUT"
+      - name: Generate changelog since last tag
+        id: generate-changelog
+        run: |
+          {
+            echo 'changelog<<EOF'
+            git log --format="* %s" ${{ steps.get-latest-tag.outputs.tag }}..HEAD | { grep -v "(IGNORE)" || :; }
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
 
-    - name: Log version & changelog
-      run: |
-        echo "Version: $VERSION"
-        echo "Version tag: $VERSION_TAG"
-        echo "Latest tag detected: $LATEST_TAG"
-        echo "Changelog: $CHANGELOG"
-      env:
-        VERSION: ${{ steps.set-version.outputs.version }}
-        VERSION_TAG: ${{ steps.set-version.outputs.version_tag }}
-        LATEST_TAG: ${{ steps.get-latest-tag.outputs.tag }}
-        CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
+      - name: Log version & changelog
+        run: |
+          echo "Version: $VERSION"
+          echo "Version tag: $VERSION_TAG"
+          echo "Latest tag detected: $LATEST_TAG"
+          echo "Changelog: $CHANGELOG"
+        env:
+          VERSION: ${{ steps.set-version.outputs.version }}
+          VERSION_TAG: ${{ steps.set-version.outputs.version_tag }}
+          LATEST_TAG: ${{ steps.get-latest-tag.outputs.tag }}
+          CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
 
-    - name: Prevent empty release
-      if: ${{ steps.generate-changelog.outputs.changelog == '' }}
-      uses: actions/github-script@v3
-      with:
-        script: |
-          core.setFailed("No changes since prior release")
+      - name: Prevent empty release
+        if: ${{ steps.generate-changelog.outputs.changelog == '' }}
+        uses: actions/github-script@v3
+        with:
+          script: |
+            core.setFailed("No changes since prior release")
 
-    - name: Update changelog
-      run: |
-        (head -8 CHANGELOG.md && echo "## $VERSION" && date "+_%d %B %Y_" && echo "" && (echo "$CHANGELOG" | sed -E 's_\(#([0-9]+)\)_([#\1](https://github.com/contentauth/c2pa-rs/pull/\1)\)_') && tail -n +9 CHANGELOG.md) > CHANGELOG.new.md
-        mv CHANGELOG.new.md CHANGELOG.md
-      env:
-        VERSION: ${{ steps.set-version.outputs.version }}
-        CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
+      - name: Update changelog
+        run: |
+          (head -8 CHANGELOG.md && echo "## $VERSION" && date "+_%d %B %Y_" && echo "" && (echo "$CHANGELOG" | sed -E 's_\(#([0-9]+)\)_([#\1](https://github.com/contentauth/c2pa-rs/pull/\1)\)_') && tail -n +9 CHANGELOG.md) > CHANGELOG.new.md
+          mv CHANGELOG.new.md CHANGELOG.md
+        env:
+          VERSION: ${{ steps.set-version.outputs.version }}
+          CHANGELOG: ${{ steps.generate-changelog.outputs.changelog }}
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
 
-    - name: Bump crate versions
-      run: |
-        sed -i "s/^version = \"[^\"]*\"$/version = \"$VERSION\"/;" Cargo.toml
-      env:
-        VERSION: ${{ steps.set-version.outputs.version }}
-    
-    - name: Update Cargo.lock
-      run: |
-        cargo update -p c2patool
+      - name: Bump crate versions
+        run: |
+          sed -i "s/^version = \"[^\"]*\"$/version = \"$VERSION\"/;" Cargo.toml
+        env:
+          VERSION: ${{ steps.set-version.outputs.version }}
 
-    - name: Report differences for "prepare (release)" commit
-      run: git diff
+      - name: Update Cargo.lock
+        run: |
+          cargo update -p c2patool
 
-    - name: Commit Cargo.toml, Cargo.lock, and changelog
-      uses: stefanzweifel/git-auto-commit-action@v4
-      id: commit
-      with:
-        commit_message: Prepare ${{ steps.set-version.outputs.version }} release
-        commit_user_name: Adobe CAI Team
-        commit_user_email: noreply@adobe.com
+      - name: Report differences for "prepare (release)" commit
+        run: git diff
 
-    - name: Create GitHub release
-      uses: ncipollo/release-action@v1
-      with:
-        body: ${{ steps.generate-changelog.outputs.changelog }}
-        commit: ${{ steps.commit.outputs.commit_hash }}
-        prerelease: true # remove at 1.0
-        tag: ${{ steps.set-version.outputs.version_tag }}
-        token: ${{ secrets.GH_ADMIN_COMMIT_TOKEN }}
+      - name: Commit Cargo.toml, Cargo.lock, and changelog
+        uses: stefanzweifel/git-auto-commit-action@v4
+        id: commit
+        with:
+          commit_message: Prepare ${{ steps.set-version.outputs.version }} release
+          commit_user_name: Adobe CAI Team
+          commit_user_email: noreply@adobe.com
+
+      - name: Create GitHub release
+        uses: ncipollo/release-action@v1
+        with:
+          body: ${{ steps.generate-changelog.outputs.changelog }}
+          commit: ${{ steps.commit.outputs.commit_hash }}
+          prerelease: false
+          tag: ${{ steps.set-version.outputs.version_tag }}
+          token: ${{ secrets.GH_ADMIN_COMMIT_TOKEN }}
 
   release-crate:
     name: Release c2patool Rust crate
     needs: repo-prep
     runs-on: ubuntu-latest
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ needs.repo-prep.outputs.commit-hash }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.repo-prep.outputs.commit-hash }}
 
-    - name: Publish crate
-      run: |
-        cargo publish --token $CRATES_IO_SECRET
-      env:
-        CRATES_IO_SECRET: ${{ secrets.CRATES_IO_SECRET }}
+      - name: Publish crate
+        run: |
+          cargo publish --token $CRATES_IO_SECRET
+        env:
+          CRATES_IO_SECRET: ${{ secrets.CRATES_IO_SECRET }}
 
   publish-binaries:
     name: Publish c2patool binaries
@@ -130,39 +130,39 @@ jobs:
         rust_version: [stable]
         experimental: [false]
         include:
-        - os: macos-latest
-          artifact_name: c2patool_mac_universal.zip
-          uploaded_asset_name: c2patool_mac_universal-${{ needs.repo-prep.outputs.new-tag }}.zip
-        - os: ubuntu-latest
-          artifact_name: c2patool_linux_intel.tar.gz
-          uploaded_asset_name: c2patool_linux_intel-${{ needs.repo-prep.outputs.new-tag }}.tar.gz
-        - os: windows-latest
-          artifact_name: c2patool_win_intel.zip
-          uploaded_asset_name: c2patool_win_intel-${{ needs.repo-prep.outputs.new-tag }}.zip
+          - os: macos-latest
+            artifact_name: c2patool_mac_universal.zip
+            uploaded_asset_name: c2patool-${{ needs.repo-prep.outputs.new-tag }}-universal-apple-darwin.zip
+          - os: ubuntu-latest
+            artifact_name: c2patool_linux_intel.tar.gz
+            uploaded_asset_name: c2patool-${{ needs.repo-prep.outputs.new-tag }}-x86_64-unknown-linux-gnu.tar.gz
+          - os: windows-latest
+            artifact_name: c2patool_win_intel.zip
+            uploaded_asset_name: c2patool-${{ needs.repo-prep.outputs.new-tag }}-x86_64-pc-windows-msvc.zip
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        ref: ${{ needs.repo-prep.outputs.commit-hash }}
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ needs.repo-prep.outputs.commit-hash }}
 
-    - name: Install Rust toolchain
-      uses: dtolnay/rust-toolchain@master
-      with:
-        toolchain: ${{ matrix.rust_version }}
-        components: llvm-tools-preview
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          components: llvm-tools-preview
 
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@v2
 
-    - name: Run make release
-      run: make release
+      - name: Run make release
+        run: make release
 
-    - name: Upload binary to GitHub
-      uses: svenstaro/upload-release-action@v1-release
-      with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: target/${{ matrix.artifact_name }}
-        asset_name: ${{ matrix.uploaded_asset_name }}
-        tag: ${{ needs.repo-prep.outputs.new-tag }}
-        overwrite: true
+      - name: Upload binary to GitHub
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: target/${{ matrix.artifact_name }}
+          asset_name: ${{ matrix.uploaded_asset_name }}
+          tag: ${{ needs.repo-prep.outputs.new-tag }}
+          overwrite: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -1176,6 +1176,16 @@ dependencies = [
  "num-bigint",
  "num-traits",
  "rusticata-macros",
+]
+
+[[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+ "serde",
 ]
 
 [[package]]
@@ -2221,7 +2231,7 @@ dependencies = [
  "md5",
  "nom",
  "rayon",
- "time 0.3.23",
+ "time 0.3.36",
  "weezl",
 ]
 
@@ -2422,6 +2432,12 @@ dependencies = [
  "smallvec",
  "zeroize",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2856,6 +2872,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3504,7 +3526,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time 0.3.23",
+ "time 0.3.36",
 ]
 
 [[package]]
@@ -3873,11 +3895,14 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
+ "deranged",
  "itoa",
+ "num-conv",
+ "powerfmt",
  "serde",
  "time-core",
  "time-macros",
@@ -3885,16 +3910,17 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -4566,7 +4592,7 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.23",
+ "time 0.3.36",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ httpmock = "0.7.0"
 predicates = "2.1"
 mockall = "0.12.1"
 
+[package.metadata.binstall]
+bin = "c2patool"
+
 [profile.release]
 strip = true  # Automatically strip symbols from the binary. 
 opt-level = 3

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Use the tool on a file in one of the [supported file formats](#supported-file-fo
 - Read a low-level report of C2PA manifest data.
 - Add a C2PA manifest to the file.
 
-For a simple example of calling c2patool from a server-based application, see the [c2pa-service-example](https://github.com/contentauth/c2pa-service-example) repository.
+For a simple example of calling c2patool from a Node.js server application, see the [c2pa-service-example](https://github.com/contentauth/c2patool-service-example) repository.
 
 <div style={{display: 'none'}}>
 
@@ -28,23 +28,44 @@ For a simple example of calling c2patool from a server-based application, see th
 
 ## Installation
 
+There are two ways to install C2PA Tool:
+- Using a pre-built binary executable: This is the quickest way to install the tool.  If you just want to try C2PA Tool quickly, use this method.
+- Using Cargo [Binstall](#using-cargo-binstall), a low-complexity way to install Rust binaries.  This method is preferable for long-term use. If you know you want to use C2PA Tool for development, use this method.  
+
+### Installing a pre-built binary
+
+The quickest way to install the tool is to use the binary executable builds.  If you just want to try C2PA Tool quickly:
+
+1. Go to the [c2patool repository releases page](https://github.com/contentauth/c2patool/releases). 
+1. Under the latest release, click **Assets**.
+1. Download the archive for your operating system (Linux, macOS, or Windows).
+1. Copy the executable file to a location on your `PATH`.
+
+Confirm that you can run the tool by entering a command such as:
+```
+c2patool -h
+```
+
+NOTE: You also may want to get some of the example files provided in the repository `sample` directory.   To do so, clone the repository with `git clone https://github.com/contentauth/c2patool.git`.
+
+### Using Cargo Binstall
+
+Installing C2PA Tool using Cargo [Binstall](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file) is recommended because it makes it easier to:
+- Automatically select the correct installation package for your platform/architecture.
+- Update the tool when a new version is released.
+- Maintain, since you don't have to manually keep track of random binaries on your system.
+- Integrate into CI or other scripting environments.
+
+Additionally, using Binstall enables you to automate code signing to ensure package integrity.
+
+#### Process
+
 **PREREQUISITE:** Install [Rust](https://www.rust-lang.org/tools/install).
 
-### Using `cargo binstall`
+To install by using Binstall:
 
-We support downloading pre-built binaries using `cargo binstall` for the Linux (x86), Mac (universal), and Windows (x86). You can install this by:
-
-1. Install cargo-binstall by following the [quick install method](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#quickly) for your OS, or by building from source by running `cargo install cargo-binstall`
-2. Run `cargo binstall c2patool`
-
-#### Upgrading
-
-You can upgrade an existing installation of c2patool by running `cargo binstall c2patool` again, or by using [cargo-update](https://github.com/nabijaczleweli/cargo-update).
-
-### Manual installation of a prebuilt binary
-
-Prebuilt versions of the tool are available for [download](https://github.com/contentauth/c2patool/tags), which you
-can download and extract to a location on your `PATH`.
+1. Install `cargo-binstall` by following the [quick install method](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#quickly) for your OS, or by building from source by running `cargo install cargo-binstall`
+2. Run `cargo binstall c2patool`.
 
 #### Upgrading
 
@@ -54,14 +75,13 @@ To ensure you have the latest version, enter this command:
 c2patool -V
 ```
 
-The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page](https://github.com/contentauth/c2patool/releases). To update to the latest version, use the installation command shown above.
+The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page](https://github.com/contentauth/c2patool/releases). 
+
+If you need to upgrade, simply run `cargo binstall c2patool` again, or use [cargo-update](https://github.com/nabijaczleweli/cargo-update).
 
 ### Building from source
 
-**NOTE:** Please use one of the prebuilt binaries above unless you are doing active development work on c2patool, or if
-a prebuilt binary is not available for your system.
-
-Enter this command to install or update the tool:
+**NOTE:** Please use one of the installation methods described above unless you are doing active development work on C2PA Tool, or if a pre-built binary is not available for your system.
 
 ```shell
 cargo install c2patool
@@ -99,7 +119,7 @@ rustup update
 
 <sup>*</sup> Fragmented MP4 is not yet supported.
 
-<sup>**</sup> Read only
+<sup>**</sup> Read-only
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,38 @@ For a simple example of calling c2patool from a server-based application, see th
 
 ## Installation
 
-Prebuilt versions of the tool are available for [download](https://github.com/contentauth/c2patool/tags).
+**PREREQUISITE:** Install [Rust](https://www.rust-lang.org/tools/install).
 
-PREREQUISITE: Install [Rust](https://www.rust-lang.org/tools/install).
+### Using `cargo binstall`
+
+We support downloading pre-built binaries using `cargo binstall` for the Linux (x86), Mac (universal), and Windows (x86). You can install this by:
+
+1. Install cargo-binstall by following the [quick install method](https://github.com/cargo-bins/cargo-binstall?tab=readme-ov-file#quickly) for your OS, or by building from source by running `cargo install cargo-binstall`
+2. Run `cargo binstall c2patool`
+
+#### Upgrading
+
+You can upgrade an existing installation of c2patool by running `cargo binstall c2patool` again, or by using [cargo-update](https://github.com/nabijaczleweli/cargo-update).
+
+### Manual installation of a prebuilt binary
+
+Prebuilt versions of the tool are available for [download](https://github.com/contentauth/c2patool/tags), which you
+can download and extract to a location on your `PATH`.
+
+#### Upgrading
+
+To ensure you have the latest version, enter this command:
+
+```
+c2patool -V
+```
+
+The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page](https://github.com/contentauth/c2patool/releases). To update to the latest version, use the installation command shown above.
+
+### Building from source
+
+**NOTE:** Please use one of the prebuilt binaries above unless you are doing active development work on c2patool, or if
+a prebuilt binary is not available for your system.
 
 Enter this command to install or update the tool:
 
@@ -45,17 +74,6 @@ NOTE: If you encounter errors installing, you may need to update your Rust insta
 ```
 rustup update
 ```
-
-### Updating
-
-To ensure you have the latest version, enter this command:
-
-```
-c2patool -V
-```
-
-The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page](https://github.com/contentauth/c2patool/releases). To update to the latest version, use the installation command shown above.
-
 
 ## Supported file formats
 
@@ -72,7 +90,7 @@ The tool will display the version installed. Compare the version number displaye
  | `mp3`         | `"audio/mpeg"`                                      |
  | `mp4`         | `video/mp4`, `application/mp4` <sup>*</sup>         |
  | `mov`         | `video/quicktime`                                   |
- | `pdf`         | `application/pdf`  <sup>**</sup>                    |
+ | `pdf`         | `application/pdf` <sup>**</sup>                     |
  | `png`         | `image/png`                                         |
  | `svg`         | `image/svg+xml`                                     |
  | `tif`,`tiff`  | `image/tiff`                                        |
@@ -95,23 +113,23 @@ Where `PATH` is the (relative or absolute) file path to the asset to read or emb
 
 The following table describes the command-line options.
 
-| CLI&nbsp;option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Short version | Argument | Description |
-|-----|----|----|----|
-| `--certs` | | N/A | Extract a certificate chain to stdout. |
-| `--config` | `-c` | `<config>` | Specifies a manifest definition as a JSON string. See [Providing a manifest definition on the command line](#providing-a-manifest-definition-on-the-command-line). |
-| `--detailed` | `-d` | N/A | Display detailed C2PA-formatted manifest data. See [Displaying a detailed manifest report](#detailed-manifest-report). |
-| `--force` | `-f` | N/A | Force overwriting output file. See [Forced overwrite](#forced-overwrite). |
-| `--help` | `-h` | N/A | Display CLI help information. |
-| `--info` |  | N/A | Display brief information about the file. |
-| `--ingredient` | `-i` | N/A | Creates an Ingredient definition in --output folder. |
-| `--output` | `-o` | `<output_file>` | Specifies path to output folder or file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file). |
-| `--manifest` | `-m` | `<manifest_file>` | Specifies a manifest file to add to an asset file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file).
-| `--no_signing_verify` | None | N/A |  Does not validate the signature after signing an asset, which speeds up signing. See [Speeding up signing](#speeding-up-signing) |
-| `--parent` | `-p` | `<parent_file>` | Specifies path to parent file. See [Specifying a parent file](#specifying-a-parent-file). |
-| `--remote` | `-r` | `<manifest_url>` | Specify URL for remote manifest available over HTTP. See [Generating a remote manifest](#generating-a-remote-manifest)| N/A? |
-| `--sidecar` | `-s` | N/A | Put manifest in external "sidecar" file with `.c2pa` extension. See [Generating an external manifest](#generating-an-external-manifest). |
-| `--tree` | | N/A | Create a tree diagram of the manifest store. |
-| `--version` | `-V` | N/A | Display version information. |
+| CLI&nbsp;option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Short version | Argument          | Description                                                                                                                                                        |
+| --------------------------------------------------------------------- | ------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--certs`                                                             |               | N/A               | Extract a certificate chain to stdout.                                                                                                                             |
+| `--config`                                                            | `-c`          | `<config>`        | Specifies a manifest definition as a JSON string. See [Providing a manifest definition on the command line](#providing-a-manifest-definition-on-the-command-line). |
+| `--detailed`                                                          | `-d`          | N/A               | Display detailed C2PA-formatted manifest data. See [Displaying a detailed manifest report](#detailed-manifest-report).                                             |
+| `--force`                                                             | `-f`          | N/A               | Force overwriting output file. See [Forced overwrite](#forced-overwrite).                                                                                          |
+| `--help`                                                              | `-h`          | N/A               | Display CLI help information.                                                                                                                                      |
+| `--info`                                                              |               | N/A               | Display brief information about the file.                                                                                                                          |
+| `--ingredient`                                                        | `-i`          | N/A               | Creates an Ingredient definition in --output folder.                                                                                                               |
+| `--output`                                                            | `-o`          | `<output_file>`   | Specifies path to output folder or file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file).                                            |
+| `--manifest`                                                          | `-m`          | `<manifest_file>` | Specifies a manifest file to add to an asset file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file).                                  |
+| `--no_signing_verify`                                                 | None          | N/A               | Does not validate the signature after signing an asset, which speeds up signing. See [Speeding up signing](#speeding-up-signing)                                   |
+| `--parent`                                                            | `-p`          | `<parent_file>`   | Specifies path to parent file. See [Specifying a parent file](#specifying-a-parent-file).                                                                          |
+| `--remote`                                                            | `-r`          | `<manifest_url>`  | Specify URL for remote manifest available over HTTP. See [Generating a remote manifest](#generating-a-remote-manifest)                                             | N/A? |
+| `--sidecar`                                                           | `-s`          | N/A               | Put manifest in external "sidecar" file with `.c2pa` extension. See [Generating an external manifest](#generating-an-external-manifest).                           |
+| `--tree`                                                              |               | N/A               | Create a tree diagram of the manifest store.                                                                                                                       |
+| `--version`                                                           | `-V`          | N/A               | Display version information.                                                                                                                                       |
 
 Use the optional `trust` sub-command to enable and configure trust support.  When you use this sub-command, several other options are available; see [Configuring trust support](#configuring-trust-support) for details.
 
@@ -266,11 +284,11 @@ c2patool [path] trust [OPTIONS]
 
 The following additional CLI options are available with the `trust` sub-command:
 
-| Option | Environment variable | Description | Example |
-| ------ | --------------- | ----------- | ------- |
+| Option            | Environment variable     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Example                                                     |
+| ----------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
 | `--trust_anchors` | `C2PATOOL_TRUST_ANCHORS` | Specifies a list of trust anchors (in PEM format) used to validate the manifest certificate chain. To be valid, the manifest certificate chain must lead to a certificate on the trust list. All certificates in the trust anchor list must have the [Basic Constraints extension](https://docs.digicert.com/en/iot-trust-manager/certificate-templates/create-json-formatted-certificate-templates/extensions/basic-constraints.html) and the CA attribute of this extension must be `True`. | `sample/trust_anchors.pem` `https://server.com/anchors.pem` |
-| `--allowed_list` | `C2PATOOL_ALLOWED_LIST` | Supersedes the `trust_anchors` check and specifies a list of end-entity certificates (in PEM format) to trust. These certificates are used to sign the manifest. The allowed list must NOT contain certificates with the [Basic Constraints extension](https://docs.digicert.com/en/iot-trust-manager/certificate-templates/create-json-formatted-certificate-templates/extensions/basic-constraints.html) with the CA attribute `True`. | `sample/allowed_list.pem` `https://server.com/allowed.pem` |
-| `--trust_config` | `C2PATOOL_TRUST_CONFIG` | Specifies a set of custom certificate extended key usages (EKUs) to allow. Format is a list with object identifiers in [OID dot notation](http://www.oid-info.com/#oid) format. | `sample/store.cfg` `https://server.com/store.cfg` |
+| `--allowed_list`  | `C2PATOOL_ALLOWED_LIST`  | Supersedes the `trust_anchors` check and specifies a list of end-entity certificates (in PEM format) to trust. These certificates are used to sign the manifest. The allowed list must NOT contain certificates with the [Basic Constraints extension](https://docs.digicert.com/en/iot-trust-manager/certificate-templates/create-json-formatted-certificate-templates/extensions/basic-constraints.html) with the CA attribute `True`.                                                      | `sample/allowed_list.pem` `https://server.com/allowed.pem`  |
+| `--trust_config`  | `C2PATOOL_TRUST_CONFIG`  | Specifies a set of custom certificate extended key usages (EKUs) to allow. Format is a list with object identifiers in [OID dot notation](http://www.oid-info.com/#oid) format.                                                                                                                                                                                                                                                                                                               | `sample/store.cfg` `https://server.com/store.cfg`           |
 
 For example:
 

--- a/README.md
+++ b/README.md
@@ -113,23 +113,23 @@ Where `PATH` is the (relative or absolute) file path to the asset to read or emb
 
 The following table describes the command-line options.
 
-| CLI&nbsp;option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Short version | Argument          | Description                                                                                                                                                        |
-| --------------------------------------------------------------------- | ------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--certs`                                                             |               | N/A               | Extract a certificate chain to stdout.                                                                                                                             |
-| `--config`                                                            | `-c`          | `<config>`        | Specifies a manifest definition as a JSON string. See [Providing a manifest definition on the command line](#providing-a-manifest-definition-on-the-command-line). |
-| `--detailed`                                                          | `-d`          | N/A               | Display detailed C2PA-formatted manifest data. See [Displaying a detailed manifest report](#detailed-manifest-report).                                             |
-| `--force`                                                             | `-f`          | N/A               | Force overwriting output file. See [Forced overwrite](#forced-overwrite).                                                                                          |
-| `--help`                                                              | `-h`          | N/A               | Display CLI help information.                                                                                                                                      |
-| `--info`                                                              |               | N/A               | Display brief information about the file.                                                                                                                          |
-| `--ingredient`                                                        | `-i`          | N/A               | Creates an Ingredient definition in --output folder.                                                                                                               |
-| `--output`                                                            | `-o`          | `<output_file>`   | Specifies path to output folder or file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file).                                            |
-| `--manifest`                                                          | `-m`          | `<manifest_file>` | Specifies a manifest file to add to an asset file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file).                                  |
-| `--no_signing_verify`                                                 | None          | N/A               | Does not validate the signature after signing an asset, which speeds up signing. See [Speeding up signing](#speeding-up-signing)                                   |
-| `--parent`                                                            | `-p`          | `<parent_file>`   | Specifies path to parent file. See [Specifying a parent file](#specifying-a-parent-file).                                                                          |
-| `--remote`                                                            | `-r`          | `<manifest_url>`  | Specify URL for remote manifest available over HTTP. See [Generating a remote manifest](#generating-a-remote-manifest)                                             | N/A? |
-| `--sidecar`                                                           | `-s`          | N/A               | Put manifest in external "sidecar" file with `.c2pa` extension. See [Generating an external manifest](#generating-an-external-manifest).                           |
-| `--tree`                                                              |               | N/A               | Create a tree diagram of the manifest store.                                                                                                                       |
-| `--version`                                                           | `-V`          | N/A               | Display version information.                                                                                                                                       |
+| CLI&nbsp;option&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; | Short version | Argument | Description |
+|-----|----|----|----|
+| `--certs` | | N/A | Extract a certificate chain to stdout. |
+| `--config` | `-c` | `<config>` | Specifies a manifest definition as a JSON string. See [Providing a manifest definition on the command line](#providing-a-manifest-definition-on-the-command-line). |
+| `--detailed` | `-d` | N/A | Display detailed C2PA-formatted manifest data. See [Displaying a detailed manifest report](#detailed-manifest-report). |
+| `--force` | `-f` | N/A | Force overwriting output file. See [Forced overwrite](#forced-overwrite). |
+| `--help` | `-h` | N/A | Display CLI help information. |
+| `--info` |  | N/A | Display brief information about the file. |
+| `--ingredient` | `-i` | N/A | Creates an Ingredient definition in --output folder. |
+| `--output` | `-o` | `<output_file>` | Specifies path to output folder or file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file). |
+| `--manifest` | `-m` | `<manifest_file>` | Specifies a manifest file to add to an asset file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file).
+| `--no_signing_verify` | None | N/A |  Does not validate the signature after signing an asset, which speeds up signing. See [Speeding up signing](#speeding-up-signing) |
+| `--parent` | `-p` | `<parent_file>` | Specifies path to parent file. See [Specifying a parent file](#specifying-a-parent-file). |
+| `--remote` | `-r` | `<manifest_url>` | Specify URL for remote manifest available over HTTP. See [Generating a remote manifest](#generating-a-remote-manifest)| N/A? |
+| `--sidecar` | `-s` | N/A | Put manifest in external "sidecar" file with `.c2pa` extension. See [Generating an external manifest](#generating-an-external-manifest). |
+| `--tree` | | N/A | Create a tree diagram of the manifest store. |
+| `--version` | `-V` | N/A | Display version information. |
 
 Use the optional `trust` sub-command to enable and configure trust support.  When you use this sub-command, several other options are available; see [Configuring trust support](#configuring-trust-support) for details.
 
@@ -284,11 +284,11 @@ c2patool [path] trust [OPTIONS]
 
 The following additional CLI options are available with the `trust` sub-command:
 
-| Option            | Environment variable     | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   | Example                                                     |
-| ----------------- | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------- |
+| Option | Environment variable | Description | Example |
+| ------ | --------------- | ----------- | ------- |
 | `--trust_anchors` | `C2PATOOL_TRUST_ANCHORS` | Specifies a list of trust anchors (in PEM format) used to validate the manifest certificate chain. To be valid, the manifest certificate chain must lead to a certificate on the trust list. All certificates in the trust anchor list must have the [Basic Constraints extension](https://docs.digicert.com/en/iot-trust-manager/certificate-templates/create-json-formatted-certificate-templates/extensions/basic-constraints.html) and the CA attribute of this extension must be `True`. | `sample/trust_anchors.pem` `https://server.com/anchors.pem` |
-| `--allowed_list`  | `C2PATOOL_ALLOWED_LIST`  | Supersedes the `trust_anchors` check and specifies a list of end-entity certificates (in PEM format) to trust. These certificates are used to sign the manifest. The allowed list must NOT contain certificates with the [Basic Constraints extension](https://docs.digicert.com/en/iot-trust-manager/certificate-templates/create-json-formatted-certificate-templates/extensions/basic-constraints.html) with the CA attribute `True`.                                                      | `sample/allowed_list.pem` `https://server.com/allowed.pem`  |
-| `--trust_config`  | `C2PATOOL_TRUST_CONFIG`  | Specifies a set of custom certificate extended key usages (EKUs) to allow. Format is a list with object identifiers in [OID dot notation](http://www.oid-info.com/#oid) format.                                                                                                                                                                                                                                                                                                               | `sample/store.cfg` `https://server.com/store.cfg`           |
+| `--allowed_list` | `C2PATOOL_ALLOWED_LIST` | Supersedes the `trust_anchors` check and specifies a list of end-entity certificates (in PEM format) to trust. These certificates are used to sign the manifest. The allowed list must NOT contain certificates with the [Basic Constraints extension](https://docs.digicert.com/en/iot-trust-manager/certificate-templates/create-json-formatted-certificate-templates/extensions/basic-constraints.html) with the CA attribute `True`. | `sample/allowed_list.pem` `https://server.com/allowed.pem` |
+| `--trust_config` | `C2PATOOL_TRUST_CONFIG` | Specifies a set of custom certificate extended key usages (EKUs) to allow. Format is a list with object identifiers in [OID dot notation](http://www.oid-info.com/#oid) format. | `sample/store.cfg` `https://server.com/store.cfg` |
 
 For example:
 


### PR DESCRIPTION
## Changes in this pull request
Since users have had some issues installing from source due to building things like OpenSSL manually, this uses [cargo binstall](https://github.com/cargo-bins/cargo-binstall) to allow users to download and install c2patool more easily using prebuilt binaries.

The main advantage with starting with this over Homebrew is that this supports all platforms, where Homebrew only supports macOS.

**Note:** I haven't been able to really test this since its difficult without having the releases posted and the crates.io information up to date, but hopefully it works. We may need to post a follow-up release or commit to `main` if there are issues.

This resolves #176.

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
