### PR TITLE
Migrate to c2pa-rs unstable_api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,9 +644,8 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "c2pa"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a646ff6654c41033c739703e7ca02c46675b7163f039740fad68b65563cd911"
+version = "0.32.1"
+source = "git+https://github.com/contentauth/c2pa-rs.git?branch=ok-nick/iter_tree#2f03a856ef55b62518fe7baf8045d1d9a50a199e"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -3864,18 +3863,18 @@ checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,14 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { version = "0.32.0", features = [
+# c2pa = { version = "0.32.0", features = [
+c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/iter_tree", features = [
+	# c2pa = { path = "../c2pa-rs/sdk", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf",
+	"unstable_api",
 ] }
 clap = { version = "4.5.2", features = ["derive", "env"] }
 env_logger = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,7 @@
 /// If only the path is given, this will generate a summary report of any claims in that file
 /// If a manifest definition json file is specified, the claim will be added to any existing claims
 use std::{
-    fs::{self, create_dir_all, remove_dir_all, File},
+    fs::{create_dir_all, remove_dir_all, File},
     io::Write,
     path::{Path, PathBuf},
     str::FromStr,
@@ -501,12 +501,12 @@ fn main() -> Result<()> {
                 for (resource_label, resource_bytes) in manifest.resources() {
                     // TODO: the labels are not normalized and should be (labels::to_normalized_uri in c2pa-rs)
                     let resource_path = manifest_path.join(resource_label);
-                    fs::create_dir_all(
+                    std::fs::create_dir_all(
                         resource_path
                             .parent()
                             .context("Failed to find resource parent path from label")?,
                     )?;
-                    fs::write(&resource_path, resource_bytes)?;
+                    std::fs::write(&resource_path, resource_bytes)?;
                 }
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -397,9 +397,8 @@ fn main() -> Result<()> {
         }
 
         if let Some(parent_path) = args.parent {
-            let ingredient = load_ingredient(&parent_path)?;
-            // TODO: Relationship isn't exported from c2pa-rs
-            // ingredient.set_relationship(Relationship::ParentOf);
+            let mut ingredient = load_ingredient(&parent_path)?;
+            ingredient.set_is_parent();
             builder.definition.ingredients.push(ingredient);
         }
 
@@ -409,9 +408,9 @@ fn main() -> Result<()> {
             .iter()
             .any(|ingredient| ingredient.is_parent());
         if !parent_exists {
-            let source_ingredient = Ingredient::from_file(&args.path)?;
+            let mut source_ingredient = Ingredient::from_file(&args.path)?;
             if source_ingredient.manifest_data().is_some() {
-                // source_ingredient.set_relationship(Relationship::ParentOf);
+                source_ingredient.set_is_parent();
                 builder.definition.ingredients.push(source_ingredient);
             }
         }
@@ -419,8 +418,6 @@ fn main() -> Result<()> {
         if let Some(remote) = args.remote {
             builder.remote_url = Some(remote);
         }
-
-        // TODO: handle sidecar
 
         if let Some(output) = args.output {
             if ext_normal(&output) != ext_normal(&args.path) {


### PR DESCRIPTION
## Changes in this pull request
Migrates `c2patool` to use the new unstable API.

Blocked by [#473](https://github.com/contentauth/c2pa-rs/pull/473) and [#474](https://github.com/contentauth/c2pa-rs/pull/474).

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
