### PR TITLE
Add `--batch` flag for batch signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The following table describes the command-line options.
 | `--force` | `-f` | N/A | Force overwriting output file. See [Forced overwrite](#forced-overwrite). |
 | `--help` | `-h` | N/A | Display CLI help information. |
 | `--info` |  | N/A | Display brief information about the file. |
+| `--batch` |  | N/A | Perform command for all children of directory (suppports signing). |
 | `--ingredient` | `-i` | N/A | Creates an Ingredient definition in --output folder. |
 | `--output` | `-o` | `<output_file>` | Specifies path to output folder or file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file). |
 | `--manifest` | `-m` | `<manifest_file>` | Specifies a manifest file to add to an asset file. See [Adding a manifest to an asset file](#adding-a-manifest-to-an-asset-file).


### PR DESCRIPTION
## Changes in this pull request
Adds `--batch` flag, which can be passed with an input and output directory to sign all children assets of a directory with the same manifest.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
