### PR TITLE
Migrate to c2pa-rs unstable API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,7 +619,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.32.1"
-source = "git+https://github.com/contentauth/c2pa-rs.git?branch=ok-nick/it+bbp#f5a42b5b78636209a0aaa5f932060961daf5dbaf"
+source = "git+https://github.com/contentauth/c2pa-rs.git?branch=ok-nick/builder_base_path#f5a42b5b78636209a0aaa5f932060961daf5dbaf"
 dependencies = [
  "asn1-rs",
  "async-generic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -618,9 +618,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "c2pa"
-version = "0.32.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a646ff6654c41033c739703e7ca02c46675b7163f039740fad68b65563cd911"
+version = "0.32.1"
 dependencies = [
  "asn1-rs",
  "async-generic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "addr2line"
-version = "0.21.0"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a30b2e23b9e17a9f90641c7ab1549cd9b44f296d3ccbf309d2863cfe398a0cb"
+checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
 dependencies = [
  "gimli",
 ]
@@ -16,6 +16,12 @@ name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "aho-corasick"
@@ -43,47 +49,48 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.13"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
 dependencies = [
  "anstyle",
  "anstyle-parse",
  "anstyle-query",
  "anstyle-wincon",
  "colorchoice",
+ "is_terminal_polyfill",
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle"
-version = "1.0.1"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
 dependencies = [
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.2"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
 dependencies = [
  "anstyle",
  "windows-sys 0.52.0",
@@ -91,15 +98,15 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
 name = "arrayref"
-version = "0.3.7"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b4930d2cb77ce62f89ee5d5289b4ac049559b1c45539271f5ed4fdc7db34545"
+checksum = "9d151e35f61089500b617991b791fc8bfd237ae50cd5950803758a179b41e67a"
 
 [[package]]
 name = "arrayvec"
@@ -135,7 +142,7 @@ dependencies = [
  "num-traits",
  "rusticata-macros",
  "thiserror",
- "time 0.3.36",
+ "time",
 ]
 
 [[package]]
@@ -194,22 +201,21 @@ dependencies = [
 
 [[package]]
 name = "async-channel"
-version = "2.2.1"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d4d23bcc79e27423727b36823d86233aad06dfea531837b038394d11e9928"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
 dependencies = [
  "concurrent-queue",
- "event-listener 5.3.0",
- "event-listener-strategy 0.5.2",
+ "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "async-executor"
-version = "1.11.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b10202063978b3351199d68f8b22c4e47e4b1b822f8d43fd862d5ea8c006b29a"
+checksum = "d7ebdfa2ebdab6b1760375fa7d6f382b9f486eac35fc994625a00e89280bdbb7"
 dependencies = [
  "async-task",
  "concurrent-queue",
@@ -226,7 +232,7 @@ checksum = "86bc01d15ca67ec7653924057aa97c30de62d06a24e6834387eba6c72c8318e7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -235,10 +241,10 @@ version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
 dependencies = [
- "async-channel 2.2.1",
+ "async-channel 2.3.1",
  "async-executor",
- "async-io 2.3.2",
- "async-lock 3.3.0",
+ "async-io 2.3.4",
+ "async-lock 3.4.0",
  "blocking",
  "futures-lite 2.3.0",
  "once_cell",
@@ -260,27 +266,27 @@ dependencies = [
  "polling 2.8.0",
  "rustix 0.37.27",
  "slab",
- "socket2 0.4.9",
+ "socket2 0.4.10",
  "waker-fn",
 ]
 
 [[package]]
 name = "async-io"
-version = "2.3.2"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcccb0f599cfa2f8ace422d3555572f47424da5648a4382a9dd0310ff8210884"
+checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
 dependencies = [
- "async-lock 3.3.0",
+ "async-lock 3.4.0",
  "cfg-if",
  "concurrent-queue",
  "futures-io",
  "futures-lite 2.3.0",
  "parking",
- "polling 3.4.0",
+ "polling 3.7.3",
  "rustix 0.38.34",
  "slab",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -294,12 +300,12 @@ dependencies = [
 
 [[package]]
 name = "async-lock"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d034b430882f8381900d3fe6f0aaa3ad94f2cb4ac519b429692a1bc2dda4ae7b"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
- "event-listener 4.0.3",
- "event-listener-strategy 0.4.0",
+ "event-listener 5.3.1",
+ "event-listener-strategy",
  "pin-project-lite",
 ]
 
@@ -314,20 +320,48 @@ dependencies = [
 
 [[package]]
 name = "async-process"
-version = "1.7.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9d28b1d97e08915212e2e45310d47854eafa69600756fc735fb788f75199c9"
+checksum = "ea6438ba0a08d81529c69b36700fa2f95837bfe3e776ab39cde9c14d9149da88"
 dependencies = [
  "async-io 1.13.0",
  "async-lock 2.8.0",
- "autocfg",
+ "async-signal",
  "blocking",
  "cfg-if",
- "event-listener 2.5.3",
+ "event-listener 3.1.0",
  "futures-lite 1.13.0",
- "rustix 0.37.27",
- "signal-hook",
+ "rustix 0.38.34",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io 2.3.4",
+ "async-lock 3.4.0",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 0.38.34",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -366,13 +400,13 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.77"
+version = "0.1.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
+checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -400,21 +434,21 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.1.0"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
 name = "backtrace"
-version = "0.3.69"
+version = "0.3.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
+checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
 dependencies = [
  "addr2line",
  "cc",
  "cfg-if",
  "libc",
- "miniz_oxide 0.7.1",
+ "miniz_oxide 0.7.4",
  "object",
  "rustc-demangle",
 ]
@@ -427,21 +461,15 @@ checksum = "4cbbc9d0964165b47557570cce6c952866c2678457aca742aafc9fb771d30270"
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
-
-[[package]]
-name = "base64"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9475866fec1451be56a3c2400fd081ff546538961565ccb5b7142cbd22bc7a51"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
@@ -462,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "bcder"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab26f019795af36086f2ca879aeeaae7566bdfd2fe0821a0328d3fdd9d1da2d9"
+checksum = "c627747a6774aab38beb35990d88309481378558875a41da1a4b2e373c906ef0"
 dependencies = [
  "bytes",
  "smallvec",
@@ -493,9 +521,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4b9d6a944f767f8e5e0db018570623c85f3d925ac718db4e06d0187adb21c1"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 dependencies = [
  "serde",
 ]
@@ -571,12 +599,11 @@ checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
 name = "blocking"
-version = "1.6.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "495f7104e962b7356f0aeb34247aca1fe7d2e783b346582db7f2904cb5717e88"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
 dependencies = [
- "async-channel 2.2.1",
- "async-lock 3.3.0",
+ "async-channel 2.3.1",
  "async-task",
  "futures-io",
  "futures-lite 2.3.0",
@@ -585,21 +612,21 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.13.0"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.14.0"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374d28ec25809ee0e23827c2ab573d729e293f281dfe393500e7ad618baa61c6"
+checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
 
 [[package]]
 name = "byteorder"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "byteordered"
@@ -612,20 +639,21 @@ dependencies = [
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "c2pa"
-version = "0.32.1"
-source = "git+https://github.com/contentauth/c2pa-rs.git?branch=ok-nick/builder_base_path#f5a42b5b78636209a0aaa5f932060961daf5dbaf"
+version = "0.33.1"
+source = "git+https://github.com/contentauth/c2pa-rs.git#345e24b2300a484ed6e41ac321d7c6b542b51852"
 dependencies = [
  "asn1-rs",
  "async-generic",
+ "async-recursion",
  "async-trait",
  "atree",
- "base64 0.21.2",
+ "base64 0.21.7",
  "bcder",
  "byteorder",
  "byteordered",
@@ -655,10 +683,11 @@ dependencies = [
  "multibase",
  "multihash",
  "openssl",
- "pem 3.0.3",
+ "pem 3.0.4",
  "png_pong",
  "rand",
  "rand_chacha",
+ "rand_core 0.9.0-alpha.2",
  "range-set",
  "rasn",
  "rasn-ocsp",
@@ -673,7 +702,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "serde_with",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "spki 0.6.0",
  "tempfile",
  "thiserror",
@@ -703,20 +732,21 @@ dependencies = [
  "log",
  "mockall",
  "openssl",
- "pem 3.0.3",
+ "pem 3.0.4",
  "reqwest",
  "serde",
  "serde_derive",
  "serde_json",
  "tempfile",
+ "termtree 0.5.1",
  "wild",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "e9e8aabfac534be767c909e0690571677d49f41bd8465ae876fe043d52ba5292"
 
 [[package]]
 name = "cfg-if"
@@ -726,25 +756,24 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.28"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ed24df0632f708f5f6d8082675bef2596f7084dee3dd55f632290bf35bfe0f"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
- "time 0.1.45",
  "wasm-bindgen",
- "windows-targets 0.48.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "ciborium"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "effd91f6c78e5a4ace8a5d3c0b6bfaec9e2baaef55f3efc00e45fb2e477ee926"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
 dependencies = [
  "ciborium-io",
  "ciborium-ll",
@@ -753,25 +782,25 @@ dependencies = [
 
 [[package]]
 name = "ciborium-io"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf919175532b369853f5d5e20b26b43112613fd6fe7aee757e35f7a44642656"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
 
 [[package]]
 name = "ciborium-ll"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defaa24ecc093c77630e6c15e17c51f5e187bf35ee514f4e2d67baaa96dae22b"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
- "half",
+ "half 2.4.1",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.2"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b230ab84b0ffdf890d5a10abdbc8b83ae1c4918275daea1ab8801f71536b2651"
+checksum = "11d8838454fda655dafd3accb2b6e2bea645b9e4078abe84a22ceb947235c5cc"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -779,33 +808,33 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.0",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.0"
+version = "4.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+checksum = "501d359d5f3dcaf6ecdeee48833ae73ec6e42723a1e52419c79abf9507eec0a0"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "color_quant"
@@ -815,9 +844,9 @@ checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
 
 [[package]]
 name = "concurrent-queue"
@@ -870,15 +899,9 @@ dependencies = [
 
 [[package]]
 name = "const-oid"
-version = "0.7.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
-
-[[package]]
-name = "const-oid"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "795bc6e66a8e340f075fcf6227e417a2dc976b92b91f3cdc778bb858778b6747"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-random"
@@ -923,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -933,15 +956,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.4"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "coset"
-version = "0.3.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c765a4e852cef25c69a48e9fcd60995a7fecabf0134a0021e7181452c4a60f95"
+checksum = "f4c8cc80f631f8307b887faca24dcc3abc427cd0367f6eb6188f6e8f5b7ad8fb"
 dependencies = [
  "ciborium",
  "ciborium-io",
@@ -949,70 +972,52 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.9"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
+checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.3.2"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "crossbeam-deque"
-version = "0.8.3"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6fd6f855243022dcecf8702fef0c297d4338e226845fe067f6341ad9fa0cef"
+checksum = "613f8cc01fe9cf1a3eb3d7f488fd2fa8388403e97039e2f73692932e291a770d"
 dependencies = [
- "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.15"
+version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae211234986c545741a7dc064309f67ee1e5ad243d0e48335adc0484d960bcc7"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
- "autocfg",
- "cfg-if",
  "crossbeam-utils",
- "memoffset",
- "scopeguard",
 ]
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.16"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a22b2d63d4d1dc0b7f1b6b2747dd0088008a9be28b6ddf0b1e7d335e3037294"
-dependencies = [
- "cfg-if",
-]
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
 name = "crunchy"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
-
-[[package]]
-name = "crypto-bigint"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c6a1d5fa1de37e071642dfa44ec552ca5b299adb128fab16138e24b548fd21"
-dependencies = [
- "generic-array",
- "subtle",
-]
 
 [[package]]
 name = "crypto-common"
@@ -1026,16 +1031,15 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "4.1.2"
+version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a677b8922c94e01bdbb12126b0bc852f00447528dee1782229af9c720c3f348"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
  "cpufeatures",
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
- "platforms",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -1049,7 +1053,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1060,9 +1064,9 @@ checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
 name = "darling"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54e36fcd13ed84ffdfda6f5be89b31287cbb80c439841fe69e04841435464391"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1070,40 +1074,40 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c2cf1c23a687a1feeb728783b993c4e1ad83d99f351801977dd809b48d0a70f"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
- "syn 2.0.52",
+ "strsim",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.8"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a668eda54683121533a393014d8692171709ff57a7d61f187b6e782719f8933f"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "data-encoding-macro"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c904b33cc60130e1aeea4956ab803d08a3f4a0ca82d64ed757afac3891f2bb99"
+checksum = "f1559b6cba622276d6d63706db152618eeb15b89b3e4041446b05876e352e639"
 dependencies = [
  "data-encoding",
  "data-encoding-macro-internal",
@@ -1111,23 +1115,12 @@ dependencies = [
 
 [[package]]
 name = "data-encoding-macro-internal"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fdf3fce3ce863539ec1d7fd1b6dcc3c645663376b43ed376bbf887733e4f772"
+checksum = "332d754c0af53bc87c108fed664d121ecf59207ec4196041f04d6ab9002ad33f"
 dependencies = [
  "data-encoding",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "der"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
-dependencies = [
- "const-oid 0.7.1",
- "crypto-bigint",
- "pem-rfc7468",
 ]
 
 [[package]]
@@ -1136,16 +1129,17 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a467a65c5e759bce6e65eaf91cc29f466cdc57cb65777bd646872a8a1fd4de"
 dependencies = [
- "const-oid 0.9.4",
+ "const-oid",
 ]
 
 [[package]]
 name = "der"
-version = "0.7.7"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c7ed52955ce76b1554f509074bb357d3fb8ac9b51288a65a3fd480d1dfba946"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
 dependencies = [
- "const-oid 0.9.4",
+ "const-oid",
+ "pem-rfc7468",
  "zeroize",
 ]
 
@@ -1189,6 +1183,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid",
  "crypto-common",
 ]
 
@@ -1215,13 +1210,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "487585f4d0c6655fe74905e2504d8ad6908e4db67f744eb140876906c2f3175d"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1251,7 +1246,7 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8 0.10.2",
+ "pkcs8",
  "signature",
 ]
 
@@ -1264,22 +1259,22 @@ dependencies = [
  "curve25519-dalek",
  "ed25519",
  "serde",
- "sha2 0.10.7",
+ "sha2 0.10.8",
  "subtle",
  "zeroize",
 ]
 
 [[package]]
 name = "either"
-version = "1.9.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "ena"
-version = "0.14.2"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533630cf40e9caa44bd91aadc88a75d75a4c3a12b4cfde353cbed41daa1e1f1"
+checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
@@ -1292,9 +1287,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.33"
+version = "0.8.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
 ]
@@ -1320,9 +1315,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a258e46cdc063eb8519c00b9fc845fc47bcfca4130e2f08e88665ceda8474245"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -1336,9 +1331,9 @@ checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "event-listener"
-version = "4.0.3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b215c49b2b248c855fb73579eb1f4f26c38ffdc12973e20e07b91d78d5646e"
+checksum = "d93877bcde0eb80ca09131a08d23f0a5c18a620b01db137dba666d18cd9b30c2"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1347,22 +1342,12 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.0"
+version = "5.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d9944b8ca13534cdfb2800775f8dd4902ff3fc75a50101466decadfdf322a24"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
 dependencies = [
  "concurrent-queue",
  "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "958e4d70b6d5e81971bebec42271ec641e7ff4e170a6fa605f2b8a8b65cb97d3"
-dependencies = [
- "event-listener 4.0.3",
  "pin-project-lite",
 ]
 
@@ -1372,7 +1357,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
 dependencies = [
- "event-listener 5.3.0",
+ "event-listener 5.3.1",
  "pin-project-lite",
 ]
 
@@ -1408,18 +1393,18 @@ checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
 name = "fdeflate"
-version = "0.3.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d329bdeac514ee06249dabc27877490f17f5d371ec693360768b838e19f3ae10"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
 dependencies = [
  "simd-adler32",
 ]
 
 [[package]]
 name = "fiat-crypto"
-version = "0.2.6"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1676f435fc1dadde4d03e43f5d62b259e1ce5f40bd4ffb21db2b42ebe59c1382"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "fixedbitset"
@@ -1429,12 +1414,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.26"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.1",
+ "miniz_oxide 0.7.4",
 ]
 
 [[package]]
@@ -1537,7 +1522,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1581,22 +1566,22 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.10"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
+checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
 
 [[package]]
 name = "glob"
@@ -1618,17 +1603,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.4"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
+checksum = "fa82e28a107a8cc405f0839610bdc9b15f1e25ec7d696aa5cf173edbcb1486ab"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "futures-util",
  "http 1.1.0",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1637,9 +1622,19 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "1.8.2"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabb4a44450da02c90444cf74558da904edde8fb4e9035a9a6a4e15445af0bd7"
+checksum = "1b43ede17f21864e81be2fa654110bf1e793774238d86ef8555c37e6519c0403"
+
+[[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
 
 [[package]]
 name = "hashbrown"
@@ -1655,15 +1650,21 @@ checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 
 [[package]]
 name = "hashbrown"
-version = "0.14.2"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93e7192158dbcda357bdec5fb5788eebf8bbac027f3f33e719d29135ae84156"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -1679,6 +1680,12 @@ name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -1721,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
  "http 1.1.0",
@@ -1731,22 +1738,22 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.8.0"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
+checksum = "0fcc0b4a115bf80b728eb8ea024ad5bd707b615bfed49e0665b6e0f86fd082d9"
 
 [[package]]
 name = "httpdate"
@@ -1764,12 +1771,12 @@ dependencies = [
  "async-object-pool",
  "async-std",
  "async-trait",
- "base64 0.21.2",
+ "base64 0.21.7",
  "basic-cookies",
  "crossbeam-utils",
  "form_urlencoded",
  "futures-util",
- "hyper 0.14.28",
+ "hyper 0.14.30",
  "lazy_static",
  "levenshtein",
  "log",
@@ -1790,9 +1797,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "0.14.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "a152ddd61dfaec7273fe8419ab357f33aee0d914c5f4efbf0d96fa749eea5ec9"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1804,7 +1811,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.5.7",
  "tokio",
  "tower-service",
  "tracing",
@@ -1813,21 +1820,39 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "50dfd22e0e76d0f662d429a5f80fcaf3855009297eab6a0a9f8543834744ba05"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "h2",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.4.1",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -1838,7 +1863,7 @@ checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.4.1",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -1848,18 +1873,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "cde7055719c54e36e95e8719f95883f22072a48ede39db7fc17a4e1d5281e9b9"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.1.0",
- "http-body 1.0.0",
- "hyper 1.1.0",
+ "http-body 1.0.1",
+ "hyper 1.4.1",
  "pin-project-lite",
- "socket2 0.5.4",
+ "socket2 0.5.7",
  "tokio",
  "tower",
  "tower-service",
@@ -1868,16 +1893,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.57"
+version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "windows",
+ "windows-core",
 ]
 
 [[package]]
@@ -1895,7 +1920,7 @@ version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ba0a11a3cf6f08d58a5629531bdb4e7c3b8b595e9812a31a7058b1176c4631e"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "byteorder",
  "flate2",
 ]
@@ -1918,15 +1943,14 @@ dependencies = [
 
 [[package]]
 name = "image"
-version = "0.24.7"
+version = "0.24.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f3dfdbdd72063086ff443e297b61695500514b1e41095b6fb9a5ab48a70a711"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
 dependencies = [
  "bytemuck",
  "byteorder",
  "color_quant",
  "jpeg-decoder",
- "num-rational",
  "num-traits",
  "png",
 ]
@@ -1955,12 +1979,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.2",
+ "hashbrown 0.14.5",
  "serde",
 ]
 
@@ -1993,9 +2017,9 @@ dependencies = [
 
 [[package]]
 name = "instant"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2021,6 +2045,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jfifdump"
@@ -2052,15 +2082,15 @@ checksum = "326647c83ea8fb213e58a272f11d4569611277d8730f9905a59fba9d30b12c05"
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
+checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -2084,18 +2114,18 @@ checksum = "17ab85f84ca42c5ec520e6f3c9966ba1fd62909ce260f8837e248857d2560509"
 
 [[package]]
 name = "keccak"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6d5ed8676d904364de097082f4e7d240b571b67989ced0240f08b7f966f940"
+checksum = "ecc2af9a1119c51f12a14607e783cb977bde58bc069ff0c3da1095e635d70654"
 dependencies = [
  "cpufeatures",
 ]
 
 [[package]]
 name = "konst"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d712a8c49d4274f8d8a5cf61368cb5f3c143d149882b1a2918129e53395fdb0"
+checksum = "50a0ba6de5f7af397afff922f22c149ff605c766cd3269cf6c1cd5e466dbe3b9"
 dependencies = [
  "const_panic",
  "konst_kernel",
@@ -2104,9 +2134,9 @@ dependencies = [
 
 [[package]]
 name = "konst_kernel"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac6ea8c376b6e208a81cf39b8e82bebf49652454d98a4829e907dac16ef1790"
+checksum = "be0a455a1719220fd6adf756088e1c69a85bf14b6a9e24537a5cc04f503edb2b"
 dependencies = [
  "typewit",
 ]
@@ -2153,11 +2183,11 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -2168,15 +2198,15 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "libm"
-version = "0.2.7"
+version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
+checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
 name = "libredox"
@@ -2184,7 +2214,7 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "libc",
 ]
 
@@ -2202,9 +2232,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01cda141df6706de531b6c46c3a33ecca755538219bd484262fa09410c13539c"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
 
 [[package]]
 name = "lock_api"
@@ -2218,9 +2248,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
@@ -2240,7 +2270,7 @@ dependencies = [
  "md5",
  "nom",
  "rayon",
- "time 0.3.36",
+ "time",
  "weezl",
 ]
 
@@ -2252,18 +2282,9 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.7.1"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
-
-[[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "mime"
@@ -2288,23 +2309,34 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
+checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
  "simd-adler32",
 ]
 
 [[package]]
-name = "mio"
-version = "0.8.8"
+name = "miniz_oxide"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
 dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.48.0",
+ "wasi",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2331,7 +2363,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2376,11 +2408,10 @@ dependencies = [
 
 [[package]]
 name = "native-tls"
-version = "0.2.11"
+version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07226173c32f2926027b63cce4bcd8076c3552846cbe7925f3aaffeac0a3b92e"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
 dependencies = [
- "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -2410,11 +2441,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.3"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
- "autocfg",
  "num-integer",
  "num-traits",
 ]
@@ -2444,19 +2474,18 @@ checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
-version = "0.1.45"
+version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
- "autocfg",
  "num-traits",
 ]
 
 [[package]]
 name = "num-iter"
-version = "0.1.43"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -2465,11 +2494,10 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
 dependencies = [
- "autocfg",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -2478,29 +2506,19 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.16"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
-]
-
-[[package]]
 name = "object"
-version = "0.32.2"
+version = "0.36.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6a622008b6e321afc04970976f62ee297fdbaa6f95318ca343e3eebb9648441"
+checksum = "27b64972346851a39438c60b341ebc01bba47464ae329e55cf343eb93964efd9"
 dependencies = [
  "memchr",
 ]
@@ -2516,23 +2534,23 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "opaque-debug"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -2549,7 +2567,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2560,18 +2578,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "300.2.3+3.2.1"
+version = "300.3.1+3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cff92b6f71555b61bb9315f7c64da3ca43d87531622120fea0195fc761b4843"
+checksum = "7259953d42a81bf137fbbd73bd30a8e1914d6dce43c2b90ed575783a22608b91"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -2598,9 +2616,9 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.2"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4af0ca4f6caed20e900d564c242b8e5d4903fdacf31d3daf527b66fe6f42fb"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2608,15 +2626,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.9"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets 0.48.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2627,28 +2645,29 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
+checksum = "6b13fe415cdf3c8e44518e18a7c95a13431d9bdf6d15367d82b23c377fdd441a"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.21.7",
+ "serde",
 ]
 
 [[package]]
 name = "pem"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8fcc794035347fb64beda2d3b462595dd2753e3f268d89c5aae77e8cf2c310"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.22.1",
  "serde",
 ]
 
 [[package]]
 name = "pem-rfc7468"
-version = "0.3.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01de5d978f34aa4b2296576379fcc416034702fd94117c56ffd8a1a767cefb30"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
 dependencies = [
  "base64ct",
 ]
@@ -2661,9 +2680,9 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f8023d0fb78c8e03784ea1c7f3fa36e68a723138990b8d5a47d916b651e7a8"
+checksum = "cd53dff83f26735fdc1ca837098ccf133605d794cdae66acfc2bfac3ec809d95"
 dependencies = [
  "memchr",
  "thiserror",
@@ -2672,9 +2691,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0d24f72393fd16ab6ac5738bc33cdb6a9aa73f8b902e8fe29cf4e67d7dd1026"
+checksum = "2a548d2beca6773b1c244554d36fcf8548a8a58e74156968211567250e48e49a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -2682,36 +2701,36 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc17e2a6c7d0a492f0158d7a4bd66cc17280308bbaff78d5bef566dca35ab80"
+checksum = "3c93a82e8d145725dcbaf44e5ea887c8a869efdcc28706df2d08c69e17077183"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.8"
+version = "2.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "934cd7631c050f4674352a6e835d5f6711ffbfb9345c2fc0107155ac495ae293"
+checksum = "a941429fea7e08bedec25e4f6785b6ffaacc6b755da98df5ef3e7dcf4a124c4f"
 dependencies = [
  "once_cell",
  "pest",
- "sha2 0.10.7",
+ "sha2 0.10.8",
 ]
 
 [[package]]
 name = "petgraph"
-version = "0.6.4"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
 ]
 
 [[package]]
@@ -2746,7 +2765,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2763,9 +2782,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "668d31b1c4eba19242f2088b2bf3316b82ca31082a8335764db4e083db7485d4"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
 dependencies = [
  "atomic-waker",
  "fastrand 2.1.0",
@@ -2774,30 +2793,19 @@ dependencies = [
 
 [[package]]
 name = "pix"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2b6992b377680150280d4708bda8207ba9e71f70507b5504f2e28d8e8e48c1"
+checksum = "5de5067af0cd27add969cdb4ef2eecc955f59235f3b7a75a3c6ac9562cfb6b81"
 
 [[package]]
 name = "pkcs1"
-version = "0.3.3"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a78f66c04ccc83dd4486fd46c33896f4e17b24a7a3a6400dedc48ed0ddd72320"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der 0.5.1",
- "pkcs8 0.8.0",
- "zeroize",
-]
-
-[[package]]
-name = "pkcs8"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cabda3fb821068a9a4fab19a683eac3af12edf0f34b94a8be53c4972b8149d0"
-dependencies = [
- "der 0.5.1",
- "spki 0.5.4",
- "zeroize",
+ "der 0.7.9",
+ "pkcs8",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -2806,42 +2814,36 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der 0.7.7",
- "spki 0.7.2",
+ "der 0.7.9",
+ "spki 0.7.3",
 ]
 
 [[package]]
 name = "pkg-config"
-version = "0.3.27"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
-name = "platforms"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "626dec3cac7cc0e1577a2ec3fc496277ec2baa084bebad95bb6fdbfae235f84c"
+checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
 name = "png"
-version = "0.17.10"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd75bf2d8dd3702b9707cdbc56a5b9ef42cec752eb8b3bafc01234558442aa64"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
 dependencies = [
  "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.7.1",
+ "miniz_oxide 0.7.4",
 ]
 
 [[package]]
 name = "png_pong"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3daa5a7330d36033a4d7239a85a65a78214a29c1a5478f1f9a9dde10fe9afffd"
+checksum = "e4ad1d272b5b15d2df3a91cca1179df91f4073c1cf29858141cb35f285d3f7c0"
 dependencies = [
- "miniz_oxide 0.7.1",
+ "miniz_oxide 0.8.0",
  "pix",
  "simd-adler32",
 ]
@@ -2864,16 +2866,17 @@ dependencies = [
 
 [[package]]
 name = "polling"
-version = "3.4.0"
+version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30054e72317ab98eddd8561db0f6524df3367636884b7b21b703e4b280a84a14"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
+ "hermit-abi 0.4.0",
  "pin-project-lite",
  "rustix 0.38.34",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2884,9 +2887,12 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "precomputed-hash"
@@ -2896,45 +2902,44 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "predicates"
-version = "3.0.3"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09963355b9f467184c04017ced4a2ba2d75cbcb4e7462690d388233253d4b1a9"
+checksum = "7e9086cc7640c29a356d1a29fd134380bee9d8f79a17410aa76e7ad295f42c97"
 dependencies = [
  "anstyle",
- "itertools 0.10.5",
  "predicates-core",
 ]
 
 [[package]]
 name = "predicates-core"
-version = "1.0.6"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b794032607612e7abeb4db69adb4e33590fa6cf1149e95fd7cb00e634b92f174"
+checksum = "ae8177bee8e75d6846599c6b9ff679ed51e882816914eec639944d7c9aa11931"
 
 [[package]]
 name = "predicates-tree"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368ba315fb8c5052ab692e68a0eefec6ec57b23a36959c14496f0b0df2c0cecf"
+checksum = "41b740d195ed3166cd147c8047ec98db0e22ec019eb8eeb76d343b795304fb13"
 dependencies = [
  "predicates-core",
- "termtree",
+ "termtree 0.4.1",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.35"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -2953,7 +2958,7 @@ checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2963,7 +2968,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2976,10 +2981,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "range-set"
-version = "0.0.9"
+name = "rand_core"
+version = "0.9.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6558ccfefeefa880f80c0e957c3748cbcf75c937900eb0604d0f2acc6a84f8dc"
+checksum = "f4e93f5a5e3c528cda9acb0928c31b2ba868c551cc46e67b778075e34aab9906"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
+name = "range-set"
+version = "0.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714bc4849c399f77ab82177e9b4f012e02f3a7d6191023e016334edde5b21050"
 dependencies = [
  "num-traits",
  "smallvec",
@@ -3044,9 +3058,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c27db03db7734835b3f53954b534c91069375ce6ccaa2e065441e07d9b6cdb1"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -3054,9 +3068,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce3fb6ad83f861aac485e76e1985cd109d9a3713802152be56c3b1f0e0658ed"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -3064,11 +3078,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -3084,9 +3098,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.4"
+version = "1.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c117dbdfde9c8308975b6a18d71f3f385c89461f7b3fb054288ecf2a2058ba4c"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3096,9 +3110,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b83b8b9847f9bf95ef68afb0b8e6cdb80f498442f5179a29fad448fcc1eaea"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -3107,17 +3121,17 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adad44e29e4c806119491a7f06f03de4d1af22c3a680dd47f1e6e179439d1f56"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "bytes",
  "encoding_rs",
  "futures-channel",
@@ -3125,9 +3139,10 @@ dependencies = [
  "futures-util",
  "h2",
  "http 1.1.0",
- "http-body 1.0.0",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.4.1",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -3169,10 +3184,25 @@ dependencies = [
  "cc",
  "libc",
  "once_cell",
- "spin",
- "untrusted",
+ "spin 0.5.2",
+ "untrusted 0.7.1",
  "web-sys",
  "winapi",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "spin 0.9.8",
+ "untrusted 0.9.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3181,28 +3211,29 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
 dependencies = [
- "base64 0.21.2",
- "bitflags 2.5.0",
+ "base64 0.21.7",
+ "bitflags 2.6.0",
  "serde",
  "serde_derive",
 ]
 
 [[package]]
 name = "rsa"
-version = "0.6.1"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cf22754c49613d2b3b119f0e5d46e34a2c628a937e3024b8762de4e7d8c710b"
+checksum = "5d0e5124fcb30e76a7e79bfee683a2746db83784b86289f6251b54b7950a0dfc"
 dependencies = [
- "byteorder",
+ "const-oid",
  "digest 0.10.7",
  "num-bigint-dig",
  "num-integer",
- "num-iter",
  "num-traits",
  "pkcs1",
- "pkcs8 0.8.0",
- "rand_core",
- "smallvec",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.8",
+ "signature",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -3219,9 +3250,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
@@ -3261,72 +3292,66 @@ version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
 dependencies = [
- "bitflags 2.5.0",
+ "bitflags 2.6.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.13",
+ "linux-raw-sys 0.4.14",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.5"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+checksum = "c58f8c84392efc0a126acce10fa59ff7b3d2ac06ab451a33f2741989b806b044"
 dependencies = [
  "log",
- "ring",
- "rustls-webpki 0.101.2",
- "sct",
+ "once_cell",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
 name = "rustls-pemfile"
-version = "2.1.2"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+checksum = "196fe16b00e106300d3e45ecfcb764fa292a535d7326a29a5875c579c7417425"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.5.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
+checksum = "fc0a2ce646f8655401bb81e7927b812614bd5d91dbc968696be50603510fcaf0"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.100.1"
+version = "0.102.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
 dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.101.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513722fd73ad80a71f72b61009ea1b584bcfa1483ca93949c8f290298837fa59"
-dependencies = [
- "ring",
- "untrusted",
+ "ring 0.17.8",
+ "rustls-pki-types",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.15"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80af6f9131f277a45a3fba6ce8e2258037bb0477a67e610d3c1fe046ab31de47"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
 
 [[package]]
 name = "ryu"
-version = "1.0.15"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "same-file"
@@ -3353,22 +3378,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "security-framework"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "770452e37cad93e0a50d5abc3990d2bc351c36d0328f86cefec2f2fb206eaef6"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -3377,9 +3392,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.10.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f3cc463c0ef97e11c3461a9d3787412d30e8e7eb907c79180c4a57bf7c04ef"
+checksum = "75da29fe9b9b08fe9d6b22b5b4bcbc75d8db3aa31e639aa56bb62e9d46bfceaf"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -3387,15 +3402,15 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d43fe69e652f3df9bdc2b85b2854a0825b86e4fb76bc44d945137d053639ca"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.197"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb1c873e1b9b056a4dc4c0c198b24c3ffa059243875552b2bd0933b1aee4ce2"
+checksum = "5b3e4cd94123dd520a128bcd11e34d9e9e423e7e3e50425cb1b4b1e3549d0284"
 dependencies = [
  "serde_derive",
 ]
@@ -3422,9 +3437,9 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.12"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab33ec92f677585af6d88c65593ae2375adde54efdbf16d597f2cbc7a6d368ff"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
 ]
@@ -3435,29 +3450,30 @@ version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bef2ebfde456fb76bbcf9f59315333decc4fda0b2b44b420243c11e0f5ec1f5"
 dependencies = [
- "half",
+ "half 1.8.3",
  "serde",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.197"
+version = "1.0.206"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
+checksum = "fabfb6138d2383ea8208cf98ccf69cdfb1aff4088460681d84189aa259762f97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.114"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f09b1bd632ef549eaa9f60a1f8de742bdbc698e6cee2095fc84dde5f549ae0"
+checksum = "66ad62847a56b3dba58cc891acd13884b9c61138d330c0d7b6181713d4fce38d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -3474,9 +3490,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "eb5b1b31579f3811bf615c144393417496f152e12ac8b7663bf664f4a815306d"
 dependencies = [
  "serde",
 ]
@@ -3495,32 +3511,32 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ad483d2ab0149d5a5ebcd9972a3852711e0153d863bf5a5d0391d28883c4a20"
+checksum = "69cecfa94848272156ea67b2b1a53f20fc7bc638c4a46d2f8abde08f05f4b857"
 dependencies = [
- "base64 0.22.0",
+ "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "serde",
  "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time 0.3.36",
+ "time",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.8.1"
+version = "3.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65569b702f41443e8bc8bbb1c5779bd0450bbe723b56198980e80ec45780bce2"
+checksum = "a8fee4991ef4f274617a51ad4af30519438dacb2f56ac773b08a1922ff743350"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3551,9 +3567,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.7"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -3573,16 +3589,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3593,9 +3599,13 @@ dependencies = [
 
 [[package]]
 name = "signature"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e1788eed21689f9cf370582dfc467ef36ed9c707f073528ddafa8d83e3b8500"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest 0.10.7",
+ "rand_core 0.6.4",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3605,9 +3615,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "similar"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa42c91313f1d05da9b26f267f931cf178d4aba455b4c4622dd7355eb80c6640"
+checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "siphasher"
@@ -3626,9 +3636,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.11.0"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
+checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
 
 [[package]]
 name = "snafu"
@@ -3647,7 +3657,7 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "990079665f075b699031e9c08fd3ab99be5029b96f3b78dc0709e8f77e4efebf"
 dependencies = [
- "heck",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -3655,9 +3665,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
+checksum = "9f7916fc008ca5542385b89a3d3ce689953c143e9304a9bf8beec1de48994c0d"
 dependencies = [
  "libc",
  "winapi",
@@ -3665,12 +3675,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.4"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
+checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
 dependencies = [
  "libc",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3680,14 +3690,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spki"
-version = "0.5.4"
+name = "spin"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44d01ac02a6ccf3e07db148d2be087da624fea0221a16152ed01f0496a6b0a27"
-dependencies = [
- "base64ct",
- "der 0.5.1",
-]
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spki"
@@ -3700,12 +3706,12 @@ dependencies = [
 
 [[package]]
 name = "spki"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1e996ef02c474957d681f1b05213dfb0abab947b446a62d37770b23500184a"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der 0.7.7",
+ "der 0.7.9",
 ]
 
 [[package]]
@@ -3723,21 +3729,15 @@ dependencies = [
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -3752,9 +3752,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.52"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b699d15b36d1f02c3e7c69f8ffef53de37aefae075d8488d4ba1a7788d574a07"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3763,9 +3763,9 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
 
 [[package]]
 name = "synstructure"
@@ -3808,14 +3808,15 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tempfile"
-version = "3.10.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85b77fafb263dd9d05cbeac119526425676db3784113aa9295c88498cbf8bff1"
+checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
 dependencies = [
  "cfg-if",
  "fastrand 2.1.0",
+ "once_cell",
  "rustix 0.38.34",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3831,9 +3832,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.2.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
 ]
@@ -3845,34 +3846,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3369f5ac52d5eb6ab48c6b4ffdc8efbcad6b89c765749064ba298f2c68a16a76"
 
 [[package]]
-name = "thiserror"
-version = "1.0.44"
+name = "termtree"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "1.0.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0342370b38b6a11b6cc11d6a805569958d54cfa061a29969c3b5ce2ea405724"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
-]
-
-[[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3917,9 +3913,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
+checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3932,31 +3928,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "daa4fb1bc778bd6f04cbfc4bb2d06a7396a8f299dc33ea1900cedaa316f467b1"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
  "mio",
- "num_cpus",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.4",
+ "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3970,24 +3965,34 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.10"
+name = "tokio-rustls"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "toml"
-version = "0.8.11"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af06656561d28735e9c1cd63dfd57132c8155426aa6af24f36a00a351f88c48e"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -3997,20 +4002,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.7"
+version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18769cd1cec395d70860ceb4d932812a0b4d06b1a4bb336745a4d21b9496e992"
+checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.2.6",
+ "indexmap 2.3.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -4030,7 +4035,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4051,7 +4055,6 @@ version = "0.1.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-core",
 ]
@@ -4079,9 +4082,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "typewit"
@@ -4106,21 +4109,21 @@ checksum = "ed646292ffc8188ef8ea4d1e0e0150fb15a5c2e12ad9b8fc191ae7a8a7f3c4b9"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.13"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
+checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
+checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
@@ -4144,17 +4147,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
-name = "ureq"
-version = "2.7.1"
+name = "untrusted"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b11c96ac7ee530603dcdf68ed1557050f374ce55a5a07193ebf8cbc9f8927e9"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b74fc6b57825be3373f7054754755f03ac3a8f5d70015ccad699ba2029956f4a"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.22.1",
  "flate2",
  "log",
  "once_cell",
  "rustls",
- "rustls-webpki 0.100.1",
+ "rustls-pki-types",
  "url",
  "webpki-roots",
 ]
@@ -4172,15 +4181,15 @@ dependencies = [
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.4.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79daa5ed5740825c40b389c5e50312b9c86df53fccd33f281df655642b43869d"
+checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 dependencies = [
  "getrandom",
  "serde",
@@ -4189,9 +4198,9 @@ dependencies = [
 
 [[package]]
 name = "value-bag"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74797339c3b98616c009c7c3eb53a0ce41e85c8ec66bd3db96ed132d20cfdee8"
+checksum = "5a84c137d37ab0142f0f2ddfe332651fdbf252e7b7dbb4e67b6c1f1b2e925101"
 
 [[package]]
 name = "vcpkg"
@@ -4201,15 +4210,15 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "waker-fn"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c4517f54858c779bbcbf228f4fca63d121bf85fbecb2dc578cdf4a39395690"
+checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
 
 [[package]]
 name = "walkdir"
@@ -4232,21 +4241,15 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
-
-[[package]]
-name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
+checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -4254,24 +4257,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
+checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.37"
+version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -4281,9 +4284,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
+checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4291,28 +4294,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
+checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.52",
+ "syn 2.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.87"
+version = "0.2.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
+checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
 
 [[package]]
 name = "web-sys"
-version = "0.3.64"
+version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
+checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4320,18 +4323,18 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "0.23.1"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
+checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
- "rustls-webpki 0.100.1",
+ "rustls-pki-types",
 ]
 
 [[package]]
 name = "weezl"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "wild"
@@ -4360,11 +4363,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "winapi",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4374,12 +4377,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.48.0"
+name = "windows-core"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -4388,7 +4391,7 @@ version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets 0.48.1",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4397,128 +4400,144 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.4",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.48.1"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.0",
- "windows_aarch64_msvc 0.48.0",
- "windows_i686_gnu 0.48.0",
- "windows_i686_msvc 0.48.0",
- "windows_x86_64_gnu 0.48.0",
- "windows_x86_64_gnullvm 0.48.0",
- "windows_x86_64_msvc 0.48.0",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
 name = "windows-targets"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd37b7e5ab9018759f893a1952c9420d060016fc19a472b4bb20d1bdd694d1b"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.4",
- "windows_aarch64_msvc 0.52.4",
- "windows_i686_gnu 0.52.4",
- "windows_i686_msvc 0.52.4",
- "windows_x86_64_gnu 0.52.4",
- "windows_x86_64_gnullvm 0.52.4",
- "windows_x86_64_msvc 0.52.4",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf46cf4c365c6f2d1cc93ce535f2c8b244591df96ceee75d8e83deb70a9cac9"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9f259dd3bcf6990b55bffd094c4f7235817ba4ceebde8e6d11cd0c5633b675"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b474d8268f99e0995f25b9f095bc7434632601028cf86590aea5c8a5cb7801d3"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1515e9a29e5bed743cb4415a9ecf5dfca648ce85ee42e15873c3cd8610ff8e02"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5eee091590e89cc02ad514ffe3ead9eb6b660aedca2183455434b93546371a03"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ca79f2451b49fa9e2af39f0747fe999fcda4f5e241b2898624dca97a1f2177"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.0"
+version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.52.4"
+version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32b752e52a2da0ddfbdbcc6fceadfeede4c939ed16d13e648833a61dfb611ed8"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.5"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dffa400e67ed5a4dd237983829e66475f0a4a26938c4b04c21baede6262215b8"
+checksum = "68a9bda4691f099d435ad181000724da8e5899daa10713c2d432552b9ccd3a6f"
 dependencies = [
  "memchr",
 ]
@@ -4544,19 +4563,19 @@ dependencies = [
 
 [[package]]
 name = "x509-certificate"
-version = "0.19.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf14059fbc1dce14de1d08535c411ba0b18749c2550a12550300da90b7ba350b"
+checksum = "5e5d27c90840e84503cf44364de338794d5d5680bdd1da6272d13f80b0769ee0"
 dependencies = [
  "bcder",
  "bytes",
  "chrono",
- "der 0.7.7",
+ "der 0.7.9",
  "hex",
- "pem 1.1.1",
- "ring",
+ "pem 2.0.1",
+ "ring 0.16.20",
  "signature",
- "spki 0.7.2",
+ "spki 0.7.3",
  "thiserror",
 ]
 
@@ -4574,14 +4593,35 @@ dependencies = [
  "oid-registry",
  "rusticata-macros",
  "thiserror",
- "time 0.3.36",
+ "time",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
+dependencies = [
+ "byteorder",
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zip"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 [[package]]
 name = "c2pa"
 version = "0.32.1"
+source = "git+https://github.com/contentauth/c2pa-rs.git?branch=ok-nick/it+bbp#f5a42b5b78636209a0aaa5f932060961daf5dbaf"
 dependencies = [
  "asn1-rs",
  "async-generic",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,7 +646,7 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 [[package]]
 name = "c2pa"
 version = "0.33.1"
-source = "git+https://github.com/contentauth/c2pa-rs.git#345e24b2300a484ed6e41ac321d7c6b542b51852"
+source = "git+https://github.com/contentauth/c2pa-rs.git?branch=ok-nick/roi#83d06b7434a4af79911df80d2d14d1c70faefe67"
 dependencies = [
  "asn1-rs",
  "async-generic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/builder_base_path", features = [
+c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
@@ -36,10 +36,11 @@ log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
 serde_json = "1.0"
-pem = "3.0.3"
+pem = "3.0.2"
 openssl = { version = "0.10.61", features = ["vendored"] }
 reqwest = { version = "0.12.4", features = ["blocking"] }
 wild = "2.2.1"
+termtree = "0.5.1"
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-# c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/iter_tree", features = [
-c2pa = { path = "../c2pa-rs/sdk", features = [
+c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/it+bbp", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/it+bbp", features = [
+c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/builder_base_path", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,8 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", features = [
+# TODO: temp use ok-nick/roi branch since our fixtures are signed using features from 2.1 spec
+c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/roi", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,11 +23,13 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { version = "0.32.0", features = [
+# c2pa = { git = "https://github.com/contentauth/c2pa-rs.git", branch = "ok-nick/iter_tree", features = [
+c2pa = { path = "../c2pa-rs/sdk", features = [
 	"fetch_remote_manifests",
 	"file_io",
 	"add_thumbnails",
 	"pdf",
+	"unstable_api",
 ] }
 clap = { version = "4.5.2", features = ["derive", "env"] }
 env_logger = "0.9"

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -16,7 +16,7 @@ use std::{
 };
 
 use anyhow::{bail, Context, Result};
-use c2pa::{jumbf_io, Ingredient, ManifestStore, Reader};
+use c2pa::{jumbf_io, Ingredient, Reader};
 use clap::Parser;
 use log::error;
 
@@ -117,10 +117,10 @@ impl Extract {
                         // Validates the jumbf refers to a valid manifest.
                         match c2pa::format_from_path(path) {
                             Some(format) => {
-                                ManifestStore::from_manifest_and_asset_bytes(
+                                Reader::from_manifest_data_and_stream(
                                     &manifest,
                                     &format,
-                                    &fs::read(path)?,
+                                    &File::open(path)?,
                                 )?;
                             }
                             None => bail!("Path `{}` is missing file extension", path.display()),
@@ -128,8 +128,8 @@ impl Extract {
                         fs::write(output, manifest)?;
                     }
                     false => {
-                        let manifest = ManifestStore::from_file(path)?;
-                        fs::write(output, manifest.to_string())?;
+                        let reader = Reader::from_file(path)?;
+                        fs::write(output, reader.to_string())?;
                     }
                 }
             }

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -223,7 +223,7 @@ impl Resources {
             let manifest_path = self.output.join(
                 manifest
                     .label()
-                    .context("Failed to get maniest label")?
+                    .context("Failed to get manifest label")?
                     .replace(':', "_"),
             );
             for resource_ref in manifest.iter_resources() {
@@ -232,7 +232,7 @@ impl Resources {
                 }
 
                 let uri = self.normalize_uri(&resource_ref.identifier);
-                let resource_path = manifest_path.join(uri);
+                let resource_path = manifest_path.join(&uri);
                 fs::create_dir_all(
                     resource_path
                         .parent()
@@ -247,7 +247,13 @@ impl Resources {
     }
 
     // TODO: this functionality should be exposed from c2pa-rs
-    fn normalize_uri<'a>(&self, uri: &'a str) -> &'a str {
-        uri.strip_prefix("self#jumbf=").unwrap_or(uri)
+    //       taken from https://github.com/contentauth/c2pa-rs/blob/2aeafd3888a6b96d00543d29a58c9783f6785f31/sdk/src/resource_store.rs#L225-L263
+    fn normalize_uri(&self, uri: &str) -> String {
+        let mut uri = uri.replace("self#jumbf=", "");
+        if uri.starts_with("/c2pa/") {
+            uri = uri.replacen("/c2pa/", "", 1);
+        }
+        uri = uri.replace([':'], "_");
+        uri
     }
 }

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -217,9 +217,7 @@ impl Resources {
                     .replace(':', "_"),
             );
             for resource_ref in manifest.iter_resources() {
-                if !self.unknown
-                    || self.unknown && resource_ref.format == "application/octet-stream"
-                {
+                if !self.unknown || resource_ref.format != "application/octet-stream" {
                     // TODO: need a method in c2pa-rs to normalize the identifier (removing jumbf tag)
                     //       maybe it should be contained within a struct/enum that impls Display
                     let resource_path = manifest_path.join(&resource_ref.identifier);

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -175,6 +175,7 @@ impl Resources {
         } else if !self.output.is_dir() {
             bail!("Output path must be a folder");
         } else if !self.force {
+            // TODO: if self.force is specified, shuld we clear the folder?
             bail!("Output path already exists use `--force` to overwrite and clear children");
         }
 
@@ -221,9 +222,8 @@ impl Resources {
                     continue;
                 }
 
-                // TODO: need a method in c2pa-rs to normalize the identifier (removing jumbf tag)
-                //       maybe it should be contained within a struct/enum that impls Display
-                let resource_path = manifest_path.join(&resource_ref.identifier);
+                let uri = self.normalize_uri(&resource_ref.identifier);
+                let resource_path = manifest_path.join(uri);
                 fs::create_dir_all(
                     resource_path
                         .parent()
@@ -235,5 +235,10 @@ impl Resources {
         }
 
         Ok(())
+    }
+
+    // TODO: this functionality should be exposed from c2pa-rs
+    fn normalize_uri<'a>(&self, uri: &'a str) -> &'a str {
+        uri.strip_prefix("self#jumbf=").unwrap_or(uri)
     }
 }

--- a/src/commands/extract.rs
+++ b/src/commands/extract.rs
@@ -217,20 +217,20 @@ impl Resources {
                     .replace(':', "_"),
             );
             for resource_ref in manifest.iter_resources() {
-                if !self.unknown || resource_ref.format != "application/octet-stream" {
-                    // TODO: need a method in c2pa-rs to normalize the identifier (removing jumbf tag)
-                    //       maybe it should be contained within a struct/enum that impls Display
-                    let resource_path = manifest_path.join(&resource_ref.identifier);
-                    fs::create_dir_all(
-                        resource_path
-                            .parent()
-                            .context("Failed to find resource parent path from label")?,
-                    )?;
-                    reader.resource_to_stream(
-                        &resource_ref.identifier,
-                        File::create(&resource_path)?,
-                    )?;
+                if !self.unknown && resource_ref.format == "application/octet-stream" {
+                    continue;
                 }
+
+                // TODO: need a method in c2pa-rs to normalize the identifier (removing jumbf tag)
+                //       maybe it should be contained within a struct/enum that impls Display
+                let resource_path = manifest_path.join(&resource_ref.identifier);
+                fs::create_dir_all(
+                    resource_path
+                        .parent()
+                        .context("Failed to find resource parent path from label")?,
+                )?;
+                reader
+                    .resource_to_stream(&resource_ref.identifier, File::create(&resource_path)?)?;
             }
         }
 

--- a/src/commands/sign.rs
+++ b/src/commands/sign.rs
@@ -46,12 +46,7 @@ pub struct Sign {
     /// Generate a .c2pa manifest file next to the output without embedding.
     #[clap(short, long)]
     pub sidecar: bool,
-    //
-    // TODO:
-    // /// Do not embed manifest and generate a .c2pa manifest file at the specified path.
-    // #[clap(short, long)]
-    // pub sidecar: Option<PathBuf>,
-    //
+
     /// Force overwrite output file(s) if they already exists.
     #[clap(short, long)]
     pub force: bool,
@@ -295,8 +290,7 @@ impl Sign {
 
         let binary_manifest = builder.sign_file(signer.as_ref(), src, dst)?;
 
-        // TODO: if sidecar is specified, expect the output to be sidecar path? or take sidecar as path instead of flag?
-        //       This could fix #134
+        // TODO: Take sidecar as output path similar to self.output, fixes #134
         if self.sidecar {
             let mut dst = dst.to_owned();
             dst.set_extension("c2pa");

--- a/src/commands/sign.rs
+++ b/src/commands/sign.rs
@@ -47,6 +47,10 @@ pub struct Sign {
     #[clap(short, long)]
     pub sidecar: bool,
 
+    /// Do not embed manifest into input.
+    #[clap(long)]
+    pub no_embed: bool,
+
     /// Force overwrite output file(s) if they already exists.
     #[clap(short, long)]
     pub force: bool,
@@ -188,7 +192,7 @@ impl Sign {
 
         // TODO: https://github.com/contentauth/c2pa-rs/pull/544
         let mut builder = Builder::from_json(&serde_json::to_string(&definition_ext.definition)?)?;
-        builder.no_embed = self.sidecar;
+        builder.no_embed = self.no_embed;
         if let Some(url) = &self.manifest_source.manifest_url {
             builder.remote_url = Some(url.to_string());
         }

--- a/src/commands/sign.rs
+++ b/src/commands/sign.rs
@@ -186,8 +186,12 @@ impl Sign {
             env::current_dir()?
         };
 
-        // TODO: we shouldn't need to reserialize this
+        // TODO: https://github.com/contentauth/c2pa-rs/pull/544
         let mut builder = Builder::from_json(&serde_json::to_string(&definition_ext.definition)?)?;
+        builder.no_embed = self.sidecar;
+        if let Some(url) = &self.manifest_source.manifest_url {
+            builder.remote_url = Some(url.to_string());
+        }
 
         if let Some(ingredients) = definition_ext.ingredients {
             for ingredient_source in ingredients {
@@ -274,10 +278,6 @@ impl Sign {
                     ingredient.with_base_path(base)?;
                 }
             }
-        }
-
-        if let Some(url) = &self.manifest_source.manifest_url {
-            builder.remote_url = Some(url.to_string());
         }
 
         sign_config.set_base_path(&base_path);

--- a/src/commands/sign.rs
+++ b/src/commands/sign.rs
@@ -14,12 +14,12 @@ use std::{
     env,
     ffi::OsStr,
     fs::{self, File},
-    io::BufReader,
+    io::{BufReader, Cursor},
     path::{Path, PathBuf},
 };
 
 use anyhow::{bail, Context, Result};
-use c2pa::{Ingredient, Manifest};
+use c2pa::{Builder, ClaimGeneratorInfo, Ingredient, ManifestDefinition};
 use clap::{Args, Parser};
 use log::{error, warn};
 use reqwest::Url;
@@ -46,7 +46,12 @@ pub struct Sign {
     /// Generate a .c2pa manifest file next to the output without embedding.
     #[clap(short, long)]
     pub sidecar: bool,
-
+    //
+    // TODO:
+    // /// Do not embed manifest and generate a .c2pa manifest file at the specified path.
+    // #[clap(short, long)]
+    // pub sidecar: Option<PathBuf>,
+    //
     /// Force overwrite output file(s) if they already exists.
     #[clap(short, long)]
     pub force: bool,
@@ -100,9 +105,9 @@ pub struct ManifestSource {
 }
 
 #[derive(Debug, Deserialize)]
-struct ExtendedManifest {
+struct ManifestDefinitionExt {
     #[serde(flatten)]
-    manifest: Manifest,
+    definition: ManifestDefinition,
     // Allows ingredients to be specified as a path or inline.
     ingredients: Option<Vec<IngredientSource>>,
 }
@@ -168,16 +173,14 @@ impl Sign {
         let mut sign_config = SignConfig::from_json(&json)?;
 
         // read the manifest information
-        let ext_manifest: ExtendedManifest = serde_json::from_str(&json)?;
-        let mut manifest = ext_manifest.manifest;
+        let mut definition_ext: ManifestDefinitionExt = serde_json::from_str(&json)?;
 
-        // add claim_tool generator so we know this was created using this tool
-        let tool_generator = format!("{}/{}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-        manifest.claim_generator = if manifest.claim_generator.starts_with("c2pa/") {
-            tool_generator // just replace the default generator
-        } else {
-            format!("{} {}", manifest.claim_generator, tool_generator)
-        };
+        let mut claim_gen_info = ClaimGeneratorInfo::new(env!("CARGO_PKG_NAME"));
+        claim_gen_info.set_version(env!("CARGO_PKG_VERSION"));
+        definition_ext
+            .definition
+            .claim_generator_info
+            .push(claim_gen_info);
 
         let base_path = if let Some(ref manifest_path) = self.manifest_source.manifest {
             fs::canonicalize(manifest_path)?
@@ -188,16 +191,29 @@ impl Sign {
             env::current_dir()?
         };
 
-        // set manifest base path before ingredients so ingredients can override it
-        manifest.with_base_path(&base_path)?;
-        sign_config.set_base_path(&base_path);
+        // TODO: we shouldn't need to reserialize this
+        let mut builder = Builder::from_json(&serde_json::to_string(&definition_ext.definition)?)?;
 
-        if let Some(ingredients) = ext_manifest.ingredients {
+        if let Some(ingredients) = definition_ext.ingredients {
             for ingredient_source in ingredients {
                 match ingredient_source {
                     IngredientSource::Ingredient(mut ingredient) => {
                         ingredient.with_base_path(&base_path)?;
-                        manifest.add_ingredient(ingredient);
+
+                        // TODO: not a beautiful sight
+                        let data = ingredient
+                            .data_ref()
+                            .map(|data_ref| ingredient.resources().get(&data_ref.identifier))
+                            .transpose()?;
+                        let data = data.as_deref().map(|data| data.as_slice()).unwrap_or(&[]);
+
+                        // TODO: shouldn't have to serialize
+                        let ingredient_json = serde_json::to_string(&ingredient)?;
+                        builder.add_ingredient(
+                            ingredient_json,
+                            ingredient.format(),
+                            &mut Cursor::new(data),
+                        )?;
                     }
                     IngredientSource::Path(mut path) => {
                         // ingredient paths are relative to the manifest path
@@ -205,40 +221,62 @@ impl Sign {
                             path = base_path.join(&path);
                         }
 
-                        manifest.add_ingredient(load_ingredient(&path)?);
+                        let ingredient = load_ingredient(&path)?;
+                        builder.add_ingredient(
+                            // TODO: shouldn't have to reserialize
+                            serde_json::to_string(&ingredient)?,
+                            ingredient.format(),
+                            // TODO: shouldn't have to read from file again
+                            &mut File::open(path)?,
+                        )?;
                     }
                 }
             }
         }
 
         if let Some(parent_path) = &self.parent {
-            manifest.set_parent(load_ingredient(parent_path)?)?;
+            let mut ingredient = load_ingredient(parent_path)?;
+            ingredient.set_is_parent();
+            builder.add_ingredient(
+                // TODO: shouldn't have to reserialize
+                serde_json::to_string(&ingredient)?,
+                ingredient.format(),
+                // TODO: shouldn't have to read from file again
+                &mut File::open(parent_path)?,
+            )?;
         }
 
         // If the source file has a manifest store, and no parent is specified treat the source as a parent.
         // note: This could be treated as an update manifest eventually since the image is the same
-        if manifest.parent().is_none() {
-            let source_ingredient = Ingredient::from_file(src)?;
+        let parent_exists = definition_ext
+            .definition
+            .ingredients
+            .iter()
+            .any(|ingredient| ingredient.is_parent());
+        if !parent_exists {
+            let mut source_ingredient = Ingredient::from_file(src)?;
             if source_ingredient.manifest_data().is_some() {
-                manifest.set_parent(source_ingredient)?;
+                source_ingredient.set_is_parent();
+                builder.add_ingredient(
+                    // TODO: we shouldn't have to reserialize this
+                    serde_json::to_string(&source_ingredient)?,
+                    source_ingredient.format(),
+                    // TODO: shouldn't have to read from file again
+                    &mut File::open(src)?,
+                )?;
             }
         }
 
-        match &input_source {
-            InputSource::Path(_) => {
-                if self.sidecar {
-                    manifest.set_sidecar_manifest();
-                }
-            }
-            InputSource::Url(url) => match self.sidecar {
-                true => {
-                    manifest.set_remote_manifest(url.to_string());
-                }
-                false => {
-                    manifest.set_embedded_manifest_with_remote_ref(url.to_string());
-                }
-            },
+        if let Some(url) = &self.manifest_source.manifest_url {
+            builder.remote_url = Some(url.to_string());
         }
+
+        sign_config.set_base_path(&base_path);
+        // TODO: since the builder reuses its ResourceStore for all ingredients, its base path can be off
+        //       for instance, ingredient/ingredient.json normally uses ../some_image.png, but since the base
+        //       path is tests/fixtures, it will be incorrect. The builder needs each ingredient to have its own
+        //       base path w/ separate resource stores
+        builder.base_path = Some(base_path);
 
         let signer = match &self.signer_path {
             Some(signer_process_name) => {
@@ -255,9 +293,15 @@ impl Sign {
             None => sign_config.signer()?,
         };
 
-        manifest
-            .embed(src, dst, signer.as_ref())
-            .context("embedding manifest")?;
+        let binary_manifest = builder.sign_file(signer.as_ref(), src, dst)?;
+
+        // TODO: if sidecar is specified, expect the output to be sidecar path? or take sidecar as path instead of flag?
+        //       This could fix #134
+        if self.sidecar {
+            let mut dst = dst.to_owned();
+            dst.set_extension("c2pa");
+            fs::write(dst, binary_manifest)?;
+        }
 
         Ok(())
     }
@@ -385,7 +429,7 @@ fn load_ingredient(path: &Path) -> Result<Ingredient> {
         let mut ingredient: Ingredient = serde_json::from_reader(reader)?;
 
         if let Some(base) = path.parent() {
-            ingredient.resources_mut().set_base_path(base);
+            ingredient.with_base_path(base)?;
         }
 
         Ok(ingredient)

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -96,7 +96,7 @@ impl View {
 
                 let reader = Reader::from_file(path)?;
                 match detailed {
-                    // TODO: c2pa-rs shouldn't output pretty by default unless if # is included (rust convention)
+                    // TODO: c2pa-rs shouldn't output pretty by default unless if # is included
                     true => println!("{:#?}", reader),
                     false => println!("{}", reader),
                 };
@@ -205,7 +205,6 @@ impl Tree {
 
         load_trust_settings(&self.trust)?;
 
-        // TODO: this doesn't include all assertions (like thumbnail, hash, ingredient, etc.)
         let reader = Reader::from_file(&self.path)?;
         match reader.active_manifest() {
             Some(active_manifest) => {

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -70,7 +70,7 @@ pub struct Tree {
     /// Input path to asset.
     path: PathBuf,
 
-    // TODO: Ideally this would provide full URNs to assertions/manifests, but we need a reliable way to
+    // TODO: Ideally this would provide full URIs to assertions/manifests, but we need a reliable way to
     //       get them or manipulate them
     // /// Display detailed information about the manifest.
     // #[clap(short, long)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<()> {
     if let Some(path) = args.path {
         return View::Manifest {
             path,
-            debug: false,
+            detailed: false,
             // To specify trust, use the explicit command `c2patool view manifest`
             trust: Trust::default(),
         }

--- a/src/signer.rs
+++ b/src/signer.rs
@@ -117,7 +117,7 @@ pub mod tests {
 
     use std::fs;
 
-    use c2pa::{Manifest, ManifestStore};
+    use c2pa::{Manifest, Reader};
 
     use super::*;
 
@@ -183,7 +183,7 @@ pub mod tests {
             .embed(SOURCE_PATH, OUTPUT_PATH, signer.as_ref())
             .expect("embed");
 
-        let ms = ManifestStore::from_file(OUTPUT_PATH)
+        let ms = Reader::from_file(OUTPUT_PATH)
             .expect("from_file")
             .to_string();
         //let ms = report_from_path(&OUTPUT_PATH, false).expect("report_from_path");

--- a/tests/fixtures/ingredient/ingredient.json
+++ b/tests/fixtures/ingredient/ingredient.json
@@ -4,7 +4,7 @@
     "instance_id": "xmp:iid:a60dfda7-0606-42db-a4f0-398ab4fb79cf",
     "thumbnail": {
       "format": "image/png",
-      "identifier": "../libpng-test.png"
+      "identifier": "libpng-test.png"
     },
     "relationship": "componentOf"
   }

--- a/tests/fixtures/ingredient/ingredient.json
+++ b/tests/fixtures/ingredient/ingredient.json
@@ -1,10 +1,10 @@
 {
-    "title": "test ingredient",
-    "format": "image/jpeg",
-    "instance_id": "xmp:iid:a60dfda7-0606-42db-a4f0-398ab4fb79cf",
-    "thumbnail": {
-      "format": "image/png",
-      "identifier": "libpng-test.png"
-    },
-    "relationship": "componentOf"
-  }
+  "title": "test ingredient",
+  "format": "image/jpeg",
+  "instance_id": "xmp:iid:a60dfda7-0606-42db-a4f0-398ab4fb79cf",
+  "thumbnail": {
+    "format": "image/png",
+    "identifier": "../libpng-test.png"
+  },
+  "relationship": "componentOf"
+}

--- a/tests/fixtures/ingredient_test.json
+++ b/tests/fixtures/ingredient_test.json
@@ -1,6 +1,6 @@
 {
     "ta_url": "http://timestamp.digicert.com",
-    
+
     "claim_generator": "TestApp",
     "claim_generator_info": [{
         "name": "Test App",

--- a/tests/snapshots/test_sign__sign-2.snap
+++ b/tests/snapshots/test_sign__sign-2.snap
@@ -55,7 +55,7 @@ expression: "ManifestStore::from_file(output_path)?"
       "label": "[MANIFEST_URN]"
     },
     "[MANIFEST_URN]": {
-      "claim_generator": "TestApp c2patool/0.9.3 c2pa-rs/0.32.0",
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
       "claim_generator_info": [
         {
           "icon": {
@@ -64,9 +64,16 @@ expression: "ManifestStore::from_file(output_path)?"
           },
           "name": "Test App",
           "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.32.1"
         }
       ],
-      "title": "C.jpg",
       "format": "image/jpeg",
       "instance_id": [XMP_ID]",
       "thumbnail": {
@@ -74,17 +81,6 @@ expression: "ManifestStore::from_file(output_path)?"
         "identifier": "[JUMBF_URI]"
       },
       "ingredients": [
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
         {
           "title": "earth_apollo17.jpg",
           "format": "image/jpeg",
@@ -116,6 +112,17 @@ expression: "ManifestStore::from_file(output_path)?"
             "identifier": "[JUMBF_URI]"
           },
           "relationship": "componentOf"
+        },
+        {
+          "title": "C.jpg",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "[MANIFEST_URN]"
         }
       ],
       "assertions": [

--- a/tests/snapshots/test_sign__sign-2.snap
+++ b/tests/snapshots/test_sign__sign-2.snap
@@ -1,23 +1,13 @@
 ---
 source: tests/test_sign.rs
-expression: "ManifestStore::from_file(output_path)?"
+expression: "unescape_json(&Reader::from_file(output_path)?.json())?"
 ---
 {
   "active_manifest": "[MANIFEST_URN]",
   "manifests": {
     "[MANIFEST_URN]": {
-      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
-      "title": "C.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [],
       "assertions": [
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "http://schema.org/",
             "@type": "CreativeWork",
@@ -28,10 +18,10 @@ expression: "ManifestStore::from_file(output_path)?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -44,90 +34,29 @@ expression: "ManifestStore::from_file(output_path)?"
                 }
               }
             ]
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
+      "format": "image/jpeg",
+      "ingredients": [],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153"
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "issuer": "C2PA Test Signing Cert"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
-      "claim_generator_info": [
-        {
-          "icon": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "name": "Test App",
-          "version": "0.0.1"
-        },
-        {
-          "name": "c2patool",
-          "version": "0.9.3"
-        },
-        {
-          "name": "c2pa-rs",
-          "version": "0.32.1"
-        }
-      ],
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [
-        {
-          "title": "earth_apollo17.jpg",
-          "format": "image/jpeg",
-          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
-          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
-        {
-          "title": "test ingredient",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        }
-      ],
+      "title": "C.jpg"
+    },
+    "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "c2pa.actions.v2",
           "data": {
             "actions": [
               {
@@ -147,7 +76,9 @@ expression: "ManifestStore::from_file(output_path)?"
                     "description": "lip synced area",
                     "region": [
                       {
-                        "time": {},
+                        "time": {
+                          "type": "npt"
+                        },
                         "type": "temporal"
                       },
                       {
@@ -193,10 +124,10 @@ expression: "ManifestStore::from_file(output_path)?"
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
               }
             ]
-          }
+          },
+          "label": "c2pa.actions.v2"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -207,10 +138,10 @@ expression: "ManifestStore::from_file(output_path)?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "cawg.training-mining",
           "data": {
             "entries": {
               "c2pa.ai_generative_training": {
@@ -220,16 +151,87 @@ expression: "ManifestStore::from_file(output_path)?"
                 "use": "allowed"
               }
             }
-          }
+          },
+          "label": "cawg.training-mining"
         }
       ],
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.33.1",
+      "claim_generator_info": [
+        {
+          "icon": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "name": "Test App",
+          "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.33.1"
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "earth_apollo17.jpg"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        },
+        {
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "test ingredient"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Es256",
-        "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "640229841392226413189608867977836244731148734950",
+        "issuer": "C2PA Test Signing Cert",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      }
     }
   }
 }

--- a/tests/snapshots/test_sign__sign_multiple-2.snap
+++ b/tests/snapshots/test_sign__sign_multiple-2.snap
@@ -55,7 +55,7 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
       "label": "[MANIFEST_URN]"
     },
     "[MANIFEST_URN]": {
-      "claim_generator": "TestApp c2patool/0.9.3 c2pa-rs/0.32.0",
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
       "claim_generator_info": [
         {
           "icon": {
@@ -64,9 +64,16 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
           },
           "name": "Test App",
           "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.32.1"
         }
       ],
-      "title": "C.jpg",
       "format": "image/jpeg",
       "instance_id": [XMP_ID]",
       "thumbnail": {
@@ -74,17 +81,6 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
         "identifier": "[JUMBF_URI]"
       },
       "ingredients": [
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
         {
           "title": "earth_apollo17.jpg",
           "format": "image/jpeg",
@@ -116,6 +112,17 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
             "identifier": "[JUMBF_URI]"
           },
           "relationship": "componentOf"
+        },
+        {
+          "title": "C.jpg",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "[MANIFEST_URN]"
         }
       ],
       "assertions": [

--- a/tests/snapshots/test_sign__sign_multiple-2.snap
+++ b/tests/snapshots/test_sign__sign_multiple-2.snap
@@ -1,23 +1,13 @@
 ---
 source: tests/test_sign.rs
-expression: "ManifestStore::from_file(output_path.join(input1_name))?"
+expression: "unescape_json(&Reader::from_file(output_path.join(input1_name))?.json())?"
 ---
 {
   "active_manifest": "[MANIFEST_URN]",
   "manifests": {
     "[MANIFEST_URN]": {
-      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
-      "title": "C.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [],
       "assertions": [
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "http://schema.org/",
             "@type": "CreativeWork",
@@ -28,10 +18,10 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -44,90 +34,29 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
                 }
               }
             ]
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
+      "format": "image/jpeg",
+      "ingredients": [],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153"
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "issuer": "C2PA Test Signing Cert"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
-      "claim_generator_info": [
-        {
-          "icon": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "name": "Test App",
-          "version": "0.0.1"
-        },
-        {
-          "name": "c2patool",
-          "version": "0.9.3"
-        },
-        {
-          "name": "c2pa-rs",
-          "version": "0.32.1"
-        }
-      ],
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [
-        {
-          "title": "earth_apollo17.jpg",
-          "format": "image/jpeg",
-          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
-          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
-        {
-          "title": "test ingredient",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        }
-      ],
+      "title": "C.jpg"
+    },
+    "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "c2pa.actions.v2",
           "data": {
             "actions": [
               {
@@ -147,7 +76,9 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
                     "description": "lip synced area",
                     "region": [
                       {
-                        "time": {},
+                        "time": {
+                          "type": "npt"
+                        },
                         "type": "temporal"
                       },
                       {
@@ -193,10 +124,10 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
               }
             ]
-          }
+          },
+          "label": "c2pa.actions.v2"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -207,10 +138,10 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "cawg.training-mining",
           "data": {
             "entries": {
               "c2pa.ai_generative_training": {
@@ -220,16 +151,87 @@ expression: "ManifestStore::from_file(output_path.join(input1_name))?"
                 "use": "allowed"
               }
             }
-          }
+          },
+          "label": "cawg.training-mining"
         }
       ],
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.33.1",
+      "claim_generator_info": [
+        {
+          "icon": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "name": "Test App",
+          "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.33.1"
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "earth_apollo17.jpg"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        },
+        {
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "test ingredient"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Es256",
-        "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "640229841392226413189608867977836244731148734950",
+        "issuer": "C2PA Test Signing Cert",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      }
     }
   }
 }

--- a/tests/snapshots/test_sign__sign_multiple-3.snap
+++ b/tests/snapshots/test_sign__sign_multiple-3.snap
@@ -1,71 +1,25 @@
 ---
 source: tests/test_sign.rs
-expression: "ManifestStore::from_file(output_path.join(input2_name))?"
+expression: "unescape_json(&Reader::from_file(output_path.join(input2_name))?.json())?"
 ---
 {
   "active_manifest": "[MANIFEST_URN]",
   "manifests": {
     "[MANIFEST_URN]": {
-      "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
-      "title": "landscape.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [
-        {
-          "title": "AdobeStock_282070651.png",
-          "format": "image/png",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "metadata": {
-            "dateTime": "2022-05-06T18:07:52.676Z"
-          }
-        }
-      ],
-      "credentials": [
-        {
-          "@context": [
-            "https://www.w3.org/2018/credentials/v1"
-          ],
-          "credentialSubject": {
-            "id": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54",
-            "name": "Pia Blumenthal"
-          },
-          "proof": {
-            "created": "2022-05-06T17:33:59.428935861Z",
-            "jws": "f119a2c5f74685624e5a0c805cae584263e1d5d2ef25b62f631aca23c512894d0d0dbec591140016adbd0ca86b388318f47e6dd8fce7cb59ea33742295a38fe06",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54"
-          },
-          "type": [
-            "VerifiableCredential"
-          ]
-        }
-      ],
       "assertions": [
         {
-          "label": "adobe.beta",
           "data": {
             "version": "0.12.5"
-          }
+          },
+          "label": "adobe.beta"
         },
         {
-          "label": "adobe.dictionary",
           "data": {
             "url": "https://cai-assertions.adobe.com/photoshop/dictionary.json"
-          }
+          },
+          "label": "adobe.dictionary"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -75,40 +29,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -121,40 +42,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -167,40 +55,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -213,40 +68,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -255,10 +77,10 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -278,57 +100,11 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               "dateTime": "2022-05-06T18:07:52.649Z",
               "reviewRatings": []
             }
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "Adobe Inc.",
-        "cert_serial_number": "117468664790937121336398959340346743515",
-        "time": "[TIMESTAMP1]"
-      },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
       "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
-      "title": "sunset.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [
-        {
-          "title": "landscape.jpg",
-          "format": "image/jpeg",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]",
-          "metadata": {
-            "dateTime": "2022-05-06T18:10:49.227Z"
-          }
-        },
-        {
-          "title": "5a680667-6da9-d84c-a5a4-bc27a6bb7e2e.jpg",
-          "format": "image/jpeg",
-          "document_id": "xmp.did:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
-          "instance_id": "xmp.iid:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "metadata": {
-            "dateTime": "2022-05-06T18:12:13.802Z"
-          }
-        }
-      ],
       "credentials": [
         {
           "@context": [
@@ -350,21 +126,50 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
           ]
         }
       ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": [XMP_ID]",
+          "format": "image/png",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:07:52.676Z"
+          },
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "AdobeStock_282070651.png"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
+      "signature_info": {
+        "alg": "Ps256",
+        "cert_serial_number": "117468664790937121336398959340346743515",
+        "issuer": "Adobe Inc.",
+        "time": "[TIMESTAMP1]"
+      },
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      },
+      "title": "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "adobe.beta",
           "data": {
             "version": "0.12.5"
-          }
+          },
+          "label": "adobe.beta"
         },
         {
-          "label": "adobe.dictionary",
           "data": {
             "url": "https://cai-assertions.adobe.com/photoshop/dictionary.json"
-          }
+          },
+          "label": "adobe.dictionary"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -374,40 +179,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -420,40 +192,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -466,40 +205,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -512,40 +218,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -554,10 +227,10 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -577,57 +250,11 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               "dateTime": "2022-05-06T18:10:49.194Z",
               "reviewRatings": []
             }
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "Adobe Inc.",
-        "cert_serial_number": "117468664790937121336398959340346743515",
-        "time": "[TIMESTAMP1]"
-      },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
       "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
-      "title": "moonrise.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [
-        {
-          "title": "sunset.jpg",
-          "format": "image/jpeg",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]",
-          "metadata": {
-            "dateTime": "2022-05-06T18:13:13.237Z"
-          }
-        },
-        {
-          "title": "AdobeStock_95590044.png",
-          "format": "image/png",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "metadata": {
-            "dateTime": "2022-05-06T18:13:51.119Z"
-          }
-        }
-      ],
       "credentials": [
         {
           "@context": [
@@ -649,21 +276,65 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
           ]
         }
       ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "document_id": [XMP_ID]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:10:49.227Z"
+          },
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "landscape.jpg"
+        },
+        {
+          "document_id": "xmp.did:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
+          "metadata": {
+            "dateTime": "2022-05-06T18:12:13.802Z"
+          },
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "5a680667-6da9-d84c-a5a4-bc27a6bb7e2e.jpg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
+      "signature_info": {
+        "alg": "Ps256",
+        "cert_serial_number": "117468664790937121336398959340346743515",
+        "issuer": "Adobe Inc.",
+        "time": "[TIMESTAMP1]"
+      },
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      },
+      "title": "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "adobe.beta",
           "data": {
             "version": "0.12.5"
-          }
+          },
+          "label": "adobe.beta"
         },
         {
-          "label": "adobe.dictionary",
           "data": {
             "url": "https://cai-assertions.adobe.com/photoshop/dictionary.json"
-          }
+          },
+          "label": "adobe.dictionary"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -673,40 +344,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -719,40 +357,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -765,40 +370,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -811,40 +383,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -853,10 +392,10 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -942,30 +481,79 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               "dateTime": "2022-05-06T18:13:13.214Z",
               "reviewRatings": []
             }
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
+      "credentials": [
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1"
+          ],
+          "credentialSubject": {
+            "id": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54",
+            "name": "Pia Blumenthal"
+          },
+          "proof": {
+            "created": "2022-05-06T17:33:59.428935861Z",
+            "jws": "f119a2c5f74685624e5a0c805cae584263e1d5d2ef25b62f631aca23c512894d0d0dbec591140016adbd0ca86b388318f47e6dd8fce7cb59ea33742295a38fe06",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54"
+          },
+          "type": [
+            "VerifiableCredential"
+          ]
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "document_id": [XMP_ID]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:13:13.237Z"
+          },
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "sunset.jpg"
+        },
+        {
+          "document_id": [XMP_ID]",
+          "format": "image/png",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:13:51.119Z"
+          },
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "AdobeStock_95590044.png"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "Adobe Inc.",
         "cert_serial_number": "117468664790937121336398959340346743515",
+        "issuer": "Adobe Inc.",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
-      "title": "C.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [],
+      "title": "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "http://schema.org/",
             "@type": "CreativeWork",
@@ -976,10 +564,10 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -992,90 +580,29 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 }
               }
             ]
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
+      "format": "image/jpeg",
+      "ingredients": [],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153"
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "issuer": "C2PA Test Signing Cert"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
-      "claim_generator_info": [
-        {
-          "icon": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "name": "Test App",
-          "version": "0.0.1"
-        },
-        {
-          "name": "c2patool",
-          "version": "0.9.3"
-        },
-        {
-          "name": "c2pa-rs",
-          "version": "0.32.1"
-        }
-      ],
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [
-        {
-          "title": "earth_apollo17.jpg",
-          "format": "image/jpeg",
-          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
-          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
-        {
-          "title": "test ingredient",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "verify.jpeg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        }
-      ],
+      "title": "C.jpg"
+    },
+    "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "c2pa.actions.v2",
           "data": {
             "actions": [
               {
@@ -1095,7 +622,9 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                     "description": "lip synced area",
                     "region": [
                       {
-                        "time": {},
+                        "time": {
+                          "type": "npt"
+                        },
                         "type": "temporal"
                       },
                       {
@@ -1141,10 +670,10 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
               }
             ]
-          }
+          },
+          "label": "c2pa.actions.v2"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -1155,10 +684,10 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "cawg.training-mining",
           "data": {
             "entries": {
               "c2pa.ai_generative_training": {
@@ -1168,16 +697,87 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
                 "use": "allowed"
               }
             }
-          }
+          },
+          "label": "cawg.training-mining"
         }
       ],
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.33.1",
+      "claim_generator_info": [
+        {
+          "icon": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "name": "Test App",
+          "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.33.1"
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "earth_apollo17.jpg"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        },
+        {
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "test ingredient"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "verify.jpeg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Es256",
-        "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "640229841392226413189608867977836244731148734950",
+        "issuer": "C2PA Test Signing Cert",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      }
     }
   }
 }

--- a/tests/snapshots/test_sign__sign_multiple-3.snap
+++ b/tests/snapshots/test_sign__sign_multiple-3.snap
@@ -1003,7 +1003,7 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
       "label": "[MANIFEST_URN]"
     },
     "[MANIFEST_URN]": {
-      "claim_generator": "TestApp c2patool/0.9.3 c2pa-rs/0.32.0",
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
       "claim_generator_info": [
         {
           "icon": {
@@ -1012,9 +1012,16 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
           },
           "name": "Test App",
           "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.32.1"
         }
       ],
-      "title": "verify.jpeg",
       "format": "image/jpeg",
       "instance_id": [XMP_ID]",
       "thumbnail": {
@@ -1022,17 +1029,6 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
         "identifier": "[JUMBF_URI]"
       },
       "ingredients": [
-        {
-          "title": "verify.jpeg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
         {
           "title": "earth_apollo17.jpg",
           "format": "image/jpeg",
@@ -1064,6 +1060,17 @@ expression: "ManifestStore::from_file(output_path.join(input2_name))?"
             "identifier": "[JUMBF_URI]"
           },
           "relationship": "componentOf"
+        },
+        {
+          "title": "verify.jpeg",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "[MANIFEST_URN]"
         }
       ],
       "assertions": [

--- a/tests/snapshots/test_sign__sign_parent-2.snap
+++ b/tests/snapshots/test_sign__sign_parent-2.snap
@@ -1,71 +1,25 @@
 ---
 source: tests/test_sign.rs
-expression: "ManifestStore::from_file(output_path)?"
+expression: "unescape_json(&Reader::from_file(output_path)?.json())?"
 ---
 {
   "active_manifest": "[MANIFEST_URN]",
   "manifests": {
     "[MANIFEST_URN]": {
-      "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
-      "title": "landscape.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [
-        {
-          "title": "AdobeStock_282070651.png",
-          "format": "image/png",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "metadata": {
-            "dateTime": "2022-05-06T18:07:52.676Z"
-          }
-        }
-      ],
-      "credentials": [
-        {
-          "@context": [
-            "https://www.w3.org/2018/credentials/v1"
-          ],
-          "credentialSubject": {
-            "id": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54",
-            "name": "Pia Blumenthal"
-          },
-          "proof": {
-            "created": "2022-05-06T17:33:59.428935861Z",
-            "jws": "f119a2c5f74685624e5a0c805cae584263e1d5d2ef25b62f631aca23c512894d0d0dbec591140016adbd0ca86b388318f47e6dd8fce7cb59ea33742295a38fe06",
-            "proofPurpose": "assertionMethod",
-            "type": "Ed25519Signature2018",
-            "verificationMethod": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54"
-          },
-          "type": [
-            "VerifiableCredential"
-          ]
-        }
-      ],
       "assertions": [
         {
-          "label": "adobe.beta",
           "data": {
             "version": "0.12.5"
-          }
+          },
+          "label": "adobe.beta"
         },
         {
-          "label": "adobe.dictionary",
           "data": {
             "url": "https://cai-assertions.adobe.com/photoshop/dictionary.json"
-          }
+          },
+          "label": "adobe.dictionary"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -75,40 +29,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -121,40 +42,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -167,40 +55,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -213,40 +68,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -255,10 +77,10 @@ expression: "ManifestStore::from_file(output_path)?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -278,57 +100,11 @@ expression: "ManifestStore::from_file(output_path)?"
               "dateTime": "2022-05-06T18:07:52.649Z",
               "reviewRatings": []
             }
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "Adobe Inc.",
-        "cert_serial_number": "117468664790937121336398959340346743515",
-        "time": "[TIMESTAMP1]"
-      },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
       "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
-      "title": "sunset.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [
-        {
-          "title": "landscape.jpg",
-          "format": "image/jpeg",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]",
-          "metadata": {
-            "dateTime": "2022-05-06T18:10:49.227Z"
-          }
-        },
-        {
-          "title": "5a680667-6da9-d84c-a5a4-bc27a6bb7e2e.jpg",
-          "format": "image/jpeg",
-          "document_id": "xmp.did:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
-          "instance_id": "xmp.iid:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "metadata": {
-            "dateTime": "2022-05-06T18:12:13.802Z"
-          }
-        }
-      ],
       "credentials": [
         {
           "@context": [
@@ -350,21 +126,50 @@ expression: "ManifestStore::from_file(output_path)?"
           ]
         }
       ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": [XMP_ID]",
+          "format": "image/png",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:07:52.676Z"
+          },
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "AdobeStock_282070651.png"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
+      "signature_info": {
+        "alg": "Ps256",
+        "cert_serial_number": "117468664790937121336398959340346743515",
+        "issuer": "Adobe Inc.",
+        "time": "[TIMESTAMP1]"
+      },
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      },
+      "title": "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "adobe.beta",
           "data": {
             "version": "0.12.5"
-          }
+          },
+          "label": "adobe.beta"
         },
         {
-          "label": "adobe.dictionary",
           "data": {
             "url": "https://cai-assertions.adobe.com/photoshop/dictionary.json"
-          }
+          },
+          "label": "adobe.dictionary"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -374,40 +179,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -420,40 +192,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -466,40 +205,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -512,40 +218,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -554,10 +227,10 @@ expression: "ManifestStore::from_file(output_path)?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -577,57 +250,11 @@ expression: "ManifestStore::from_file(output_path)?"
               "dateTime": "2022-05-06T18:10:49.194Z",
               "reviewRatings": []
             }
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
-      "signature_info": {
-        "alg": "Ps256",
-        "issuer": "Adobe Inc.",
-        "cert_serial_number": "117468664790937121336398959340346743515",
-        "time": "[TIMESTAMP1]"
-      },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
       "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
-      "title": "moonrise.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [
-        {
-          "title": "sunset.jpg",
-          "format": "image/jpeg",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]",
-          "metadata": {
-            "dateTime": "2022-05-06T18:13:13.237Z"
-          }
-        },
-        {
-          "title": "AdobeStock_95590044.png",
-          "format": "image/png",
-          "document_id": [XMP_ID]",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "metadata": {
-            "dateTime": "2022-05-06T18:13:51.119Z"
-          }
-        }
-      ],
       "credentials": [
         {
           "@context": [
@@ -649,21 +276,65 @@ expression: "ManifestStore::from_file(output_path)?"
           ]
         }
       ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "document_id": [XMP_ID]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:10:49.227Z"
+          },
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "landscape.jpg"
+        },
+        {
+          "document_id": "xmp.did:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:a0ca6da8-6bc2-4d37-b4e1-a5867a933899",
+          "metadata": {
+            "dateTime": "2022-05-06T18:12:13.802Z"
+          },
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "5a680667-6da9-d84c-a5a4-bc27a6bb7e2e.jpg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
+      "signature_info": {
+        "alg": "Ps256",
+        "cert_serial_number": "117468664790937121336398959340346743515",
+        "issuer": "Adobe Inc.",
+        "time": "[TIMESTAMP1]"
+      },
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      },
+      "title": "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "adobe.beta",
           "data": {
             "version": "0.12.5"
-          }
+          },
+          "label": "adobe.beta"
         },
         {
-          "label": "adobe.dictionary",
           "data": {
             "url": "https://cai-assertions.adobe.com/photoshop/dictionary.json"
-          }
+          },
+          "label": "adobe.dictionary"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -673,40 +344,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -719,40 +357,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -765,40 +370,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -811,40 +383,7 @@ expression: "ManifestStore::from_file(output_path)?"
                 "credential": [
                   {
                     "alg": "sha256",
-                    "hash": [
-                      203,
-                      120,
-                      131,
-                      22,
-                      117,
-                      46,
-                      127,
-                      210,
-                      39,
-                      76,
-                      145,
-                      131,
-                      37,
-                      153,
-                      227,
-                      127,
-                      64,
-                      153,
-                      152,
-                      132,
-                      20,
-                      227,
-                      17,
-                      46,
-                      224,
-                      26,
-                      227,
-                      217,
-                      253,
-                      19,
-                      49,
-                      10
-                    ],
+                    "hash": "y3iDFnUuf9InTJGDJZnjf0CZmIQU4xEu4Brj2f0TMQo=",
                     "url": "[JUMBF_URI]"
                   }
                 ],
@@ -853,10 +392,10 @@ expression: "ManifestStore::from_file(output_path)?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -942,30 +481,79 @@ expression: "ManifestStore::from_file(output_path)?"
               "dateTime": "2022-05-06T18:13:13.214Z",
               "reviewRatings": []
             }
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "Adobe Photoshop 23.3.1 (build 20220419.r.426 4d24a4c; mac; ContentCredentials 37f01a3)",
+      "credentials": [
+        {
+          "@context": [
+            "https://www.w3.org/2018/credentials/v1"
+          ],
+          "credentialSubject": {
+            "id": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54",
+            "name": "Pia Blumenthal"
+          },
+          "proof": {
+            "created": "2022-05-06T17:33:59.428935861Z",
+            "jws": "f119a2c5f74685624e5a0c805cae584263e1d5d2ef25b62f631aca23c512894d0d0dbec591140016adbd0ca86b388318f47e6dd8fce7cb59ea33742295a38fe06",
+            "proofPurpose": "assertionMethod",
+            "type": "Ed25519Signature2018",
+            "verificationMethod": "did:adobe:f68e498f51ffd0a70dff98fec87cfd834107424ae0c13775bc17e60bd15e66f54"
+          },
+          "type": [
+            "VerifiableCredential"
+          ]
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "document_id": [XMP_ID]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:13:13.237Z"
+          },
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "sunset.jpg"
+        },
+        {
+          "document_id": [XMP_ID]",
+          "format": "image/png",
+          "instance_id": [XMP_ID]",
+          "metadata": {
+            "dateTime": "2022-05-06T18:13:51.119Z"
+          },
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "AdobeStock_95590044.png"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "Adobe Inc.",
         "cert_serial_number": "117468664790937121336398959340346743515",
+        "issuer": "Adobe Inc.",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
-      "title": "C.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [],
+      "title": "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "http://schema.org/",
             "@type": "CreativeWork",
@@ -976,10 +564,10 @@ expression: "ManifestStore::from_file(output_path)?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -992,101 +580,29 @@ expression: "ManifestStore::from_file(output_path)?"
                 }
               }
             ]
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
+      "format": "image/jpeg",
+      "ingredients": [],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153"
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "issuer": "C2PA Test Signing Cert"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
-      "claim_generator_info": [
-        {
-          "icon": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "name": "Test App",
-          "version": "0.0.1"
-        },
-        {
-          "name": "c2patool",
-          "version": "0.9.3"
-        },
-        {
-          "name": "c2pa-rs",
-          "version": "0.32.1"
-        }
-      ],
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [
-        {
-          "title": "earth_apollo17.jpg",
-          "format": "image/jpeg",
-          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
-          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
-        {
-          "title": "test ingredient",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "verify.jpeg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        }
-      ],
+      "title": "C.jpg"
+    },
+    "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "c2pa.actions.v2",
           "data": {
             "actions": [
               {
@@ -1106,7 +622,9 @@ expression: "ManifestStore::from_file(output_path)?"
                     "description": "lip synced area",
                     "region": [
                       {
-                        "time": {},
+                        "time": {
+                          "type": "npt"
+                        },
                         "type": "temporal"
                       },
                       {
@@ -1152,10 +670,10 @@ expression: "ManifestStore::from_file(output_path)?"
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
               }
             ]
-          }
+          },
+          "label": "c2pa.actions.v2"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -1166,10 +684,10 @@ expression: "ManifestStore::from_file(output_path)?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "cawg.training-mining",
           "data": {
             "entries": {
               "c2pa.ai_generative_training": {
@@ -1179,23 +697,105 @@ expression: "ManifestStore::from_file(output_path)?"
                 "use": "allowed"
               }
             }
-          }
+          },
+          "label": "cawg.training-mining"
         }
       ],
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.33.1",
+      "claim_generator_info": [
+        {
+          "icon": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "name": "Test App",
+          "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.33.1"
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "earth_apollo17.jpg"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        },
+        {
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "test ingredient"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "verify.jpeg"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Es256",
-        "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "640229841392226413189608867977836244731148734950",
+        "issuer": "C2PA Test Signing Cert",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      }
     }
   },
   "validation_status": [
     {
       "code": "manifest.multipleParents",
-      "url": "[JUMBF_URI]",
-      "explanation": "too many ingredient parents"
+      "explanation": "too many ingredient parents",
+      "url": "[JUMBF_URI]"
     }
   ]
 }

--- a/tests/snapshots/test_sign__sign_parent-2.snap
+++ b/tests/snapshots/test_sign__sign_parent-2.snap
@@ -1003,7 +1003,7 @@ expression: "ManifestStore::from_file(output_path)?"
       "label": "[MANIFEST_URN]"
     },
     "[MANIFEST_URN]": {
-      "claim_generator": "TestApp c2patool/0.9.3 c2pa-rs/0.32.0",
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
       "claim_generator_info": [
         {
           "icon": {
@@ -1012,9 +1012,16 @@ expression: "ManifestStore::from_file(output_path)?"
           },
           "name": "Test App",
           "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.32.1"
         }
       ],
-      "title": "C.jpg",
       "format": "image/jpeg",
       "instance_id": [XMP_ID]",
       "thumbnail": {
@@ -1022,17 +1029,6 @@ expression: "ManifestStore::from_file(output_path)?"
         "identifier": "[JUMBF_URI]"
       },
       "ingredients": [
-        {
-          "title": "verify.jpeg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
         {
           "title": "earth_apollo17.jpg",
           "format": "image/jpeg",
@@ -1064,6 +1060,28 @@ expression: "ManifestStore::from_file(output_path)?"
             "identifier": "[JUMBF_URI]"
           },
           "relationship": "componentOf"
+        },
+        {
+          "title": "verify.jpeg",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "[MANIFEST_URN]"
+        },
+        {
+          "title": "C.jpg",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "[MANIFEST_URN]"
         }
       ],
       "assertions": [
@@ -1172,5 +1190,12 @@ expression: "ManifestStore::from_file(output_path)?"
       },
       "label": "[MANIFEST_URN]"
     }
-  }
+  },
+  "validation_status": [
+    {
+      "code": "manifest.multipleParents",
+      "url": "[JUMBF_URI]",
+      "explanation": "too many ingredient parents"
+    }
+  ]
 }

--- a/tests/snapshots/test_sign__sign_sidecar-2.snap
+++ b/tests/snapshots/test_sign__sign_sidecar-2.snap
@@ -55,7 +55,7 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
       "label": "[MANIFEST_URN]"
     },
     "[MANIFEST_URN]": {
-      "claim_generator": "TestApp c2patool/0.9.3 c2pa-rs/0.32.0",
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
       "claim_generator_info": [
         {
           "icon": {
@@ -64,9 +64,16 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
           },
           "name": "Test App",
           "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.32.1"
         }
       ],
-      "title": "C.jpg",
       "format": "image/jpeg",
       "instance_id": [XMP_ID]",
       "thumbnail": {
@@ -74,17 +81,6 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
         "identifier": "[JUMBF_URI]"
       },
       "ingredients": [
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
         {
           "title": "earth_apollo17.jpg",
           "format": "image/jpeg",
@@ -116,6 +112,17 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
             "identifier": "[JUMBF_URI]"
           },
           "relationship": "componentOf"
+        },
+        {
+          "title": "C.jpg",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "[MANIFEST_URN]"
         }
       ],
       "assertions": [

--- a/tests/snapshots/test_sign__sign_sidecar-2.snap
+++ b/tests/snapshots/test_sign__sign_sidecar-2.snap
@@ -1,23 +1,13 @@
 ---
 source: tests/test_sign.rs
-expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
+expression: "unescape_json(&Reader::from_file(output_path.join(\"C.jpg\"))?.json())?"
 ---
 {
   "active_manifest": "[MANIFEST_URN]",
   "manifests": {
     "[MANIFEST_URN]": {
-      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
-      "title": "C.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [],
       "assertions": [
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "http://schema.org/",
             "@type": "CreativeWork",
@@ -28,10 +18,10 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -44,90 +34,29 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
                 }
               }
             ]
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
+      "format": "image/jpeg",
+      "ingredients": [],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153"
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "issuer": "C2PA Test Signing Cert"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
-      "claim_generator_info": [
-        {
-          "icon": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "name": "Test App",
-          "version": "0.0.1"
-        },
-        {
-          "name": "c2patool",
-          "version": "0.9.3"
-        },
-        {
-          "name": "c2pa-rs",
-          "version": "0.32.1"
-        }
-      ],
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [
-        {
-          "title": "earth_apollo17.jpg",
-          "format": "image/jpeg",
-          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
-          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
-        {
-          "title": "test ingredient",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        }
-      ],
+      "title": "C.jpg"
+    },
+    "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "c2pa.actions.v2",
           "data": {
             "actions": [
               {
@@ -147,7 +76,9 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
                     "description": "lip synced area",
                     "region": [
                       {
-                        "time": {},
+                        "time": {
+                          "type": "npt"
+                        },
                         "type": "temporal"
                       },
                       {
@@ -193,10 +124,10 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
               }
             ]
-          }
+          },
+          "label": "c2pa.actions.v2"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -207,10 +138,10 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "cawg.training-mining",
           "data": {
             "entries": {
               "c2pa.ai_generative_training": {
@@ -220,16 +151,87 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.jpg\"))?"
                 "use": "allowed"
               }
             }
-          }
+          },
+          "label": "cawg.training-mining"
         }
       ],
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.33.1",
+      "claim_generator_info": [
+        {
+          "icon": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "name": "Test App",
+          "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.33.1"
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "earth_apollo17.jpg"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        },
+        {
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "test ingredient"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Es256",
-        "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "640229841392226413189608867977836244731148734950",
+        "issuer": "C2PA Test Signing Cert",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      }
     }
   }
 }

--- a/tests/snapshots/test_sign__sign_sidecar-3.snap
+++ b/tests/snapshots/test_sign__sign_sidecar-3.snap
@@ -1,23 +1,13 @@
 ---
 source: tests/test_sign.rs
-expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
+expression: "unescape_json(&Reader::from_file(output_path.join(\"C.c2pa\"))?.json())?"
 ---
 {
   "active_manifest": "[MANIFEST_URN]",
   "manifests": {
     "[MANIFEST_URN]": {
-      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
-      "title": "C.jpg",
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
-      "thumbnail": {
-        "format": "image/jpeg",
-        "identifier": "[JUMBF_URI]"
-      },
-      "ingredients": [],
       "assertions": [
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "http://schema.org/",
             "@type": "CreativeWork",
@@ -28,10 +18,10 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "c2pa.actions",
           "data": {
             "actions": [
               {
@@ -44,90 +34,29 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
                 }
               }
             ]
-          }
+          },
+          "label": "c2pa.actions"
         }
       ],
+      "claim_generator": "make_test_images/0.6.1 c2pa-rs/0.6.1",
+      "format": "image/jpeg",
+      "ingredients": [],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Ps256",
-        "issuer": "C2PA Test Signing Cert",
-        "cert_serial_number": "720724073027128164015125666832722375746636448153"
+        "cert_serial_number": "720724073027128164015125666832722375746636448153",
+        "issuer": "C2PA Test Signing Cert"
       },
-      "label": "[MANIFEST_URN]"
-    },
-    "[MANIFEST_URN]": {
-      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
-      "claim_generator_info": [
-        {
-          "icon": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "name": "Test App",
-          "version": "0.0.1"
-        },
-        {
-          "name": "c2patool",
-          "version": "0.9.3"
-        },
-        {
-          "name": "c2pa-rs",
-          "version": "0.32.1"
-        }
-      ],
-      "format": "image/jpeg",
-      "instance_id": [XMP_ID]",
       "thumbnail": {
         "format": "image/jpeg",
         "identifier": "[JUMBF_URI]"
       },
-      "ingredients": [
-        {
-          "title": "earth_apollo17.jpg",
-          "format": "image/jpeg",
-          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
-          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
-        {
-          "title": "test ingredient",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/png",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "componentOf"
-        },
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        }
-      ],
+      "title": "C.jpg"
+    },
+    "[MANIFEST_URN]": {
       "assertions": [
         {
-          "label": "c2pa.actions.v2",
           "data": {
             "actions": [
               {
@@ -147,7 +76,9 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
                     "description": "lip synced area",
                     "region": [
                       {
-                        "time": {},
+                        "time": {
+                          "type": "npt"
+                        },
                         "type": "temporal"
                       },
                       {
@@ -193,10 +124,10 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
                 "digitalSourceType": "http://cv.iptc.org/newscodes/digitalsourcetype/minorHumanEdits"
               }
             ]
-          }
+          },
+          "label": "c2pa.actions.v2"
         },
         {
-          "label": "stds.schema-org.CreativeWork",
           "data": {
             "@context": "https://schema.org",
             "@type": "CreativeWork",
@@ -207,10 +138,10 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
               }
             ]
           },
-          "kind": "Json"
+          "kind": "Json",
+          "label": "stds.schema-org.CreativeWork"
         },
         {
-          "label": "cawg.training-mining",
           "data": {
             "entries": {
               "c2pa.ai_generative_training": {
@@ -220,23 +151,94 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
                 "use": "allowed"
               }
             }
-          }
+          },
+          "label": "cawg.training-mining"
         }
       ],
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.33.1",
+      "claim_generator_info": [
+        {
+          "icon": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "name": "Test App",
+          "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.33.1"
+        }
+      ],
+      "format": "image/jpeg",
+      "ingredients": [
+        {
+          "document_id": "adobe:docid:photoshop:e1c344db-c371-ef45-a4fe-9b5ba6346544",
+          "format": "image/jpeg",
+          "instance_id": "xmp.iid:9867c3b4-465e-42e4-8064-76c0c0fe3d16",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "earth_apollo17.jpg"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        },
+        {
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "componentOf",
+          "thumbnail": {
+            "format": "image/png",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "test ingredient"
+        },
+        {
+          "active_manifest": "[MANIFEST_URN]",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "relationship": "parentOf",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "title": "C.jpg"
+        }
+      ],
+      "instance_id": [XMP_ID]",
+      "label": "[MANIFEST_URN]",
       "signature_info": {
         "alg": "Es256",
-        "issuer": "C2PA Test Signing Cert",
         "cert_serial_number": "640229841392226413189608867977836244731148734950",
+        "issuer": "C2PA Test Signing Cert",
         "time": "[TIMESTAMP1]"
       },
-      "label": "[MANIFEST_URN]"
+      "thumbnail": {
+        "format": "image/jpeg",
+        "identifier": "[JUMBF_URI]"
+      }
     }
   },
   "validation_status": [
     {
       "code": "assertion.dataHash.mismatch",
-      "url": "[JUMBF_URI]",
-      "explanation": "asset hash error, name: jumbf manifest, error: hash verification( Hashes do not match )"
+      "explanation": "asset hash error, name: jumbf manifest, error: hash verification( Hashes do not match )",
+      "url": "[JUMBF_URI]"
     }
   ]
 }

--- a/tests/snapshots/test_sign__sign_sidecar-3.snap
+++ b/tests/snapshots/test_sign__sign_sidecar-3.snap
@@ -55,7 +55,7 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
       "label": "[MANIFEST_URN]"
     },
     "[MANIFEST_URN]": {
-      "claim_generator": "TestApp c2patool/0.9.3 c2pa-rs/0.32.0",
+      "claim_generator": "test_app/0.0.1 c2patool/0.9.3 c2pa-rs/0.32.1",
       "claim_generator_info": [
         {
           "icon": {
@@ -64,9 +64,16 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
           },
           "name": "Test App",
           "version": "0.0.1"
+        },
+        {
+          "name": "c2patool",
+          "version": "0.9.3"
+        },
+        {
+          "name": "c2pa-rs",
+          "version": "0.32.1"
         }
       ],
-      "title": "C.jpg",
       "format": "image/jpeg",
       "instance_id": [XMP_ID]",
       "thumbnail": {
@@ -74,17 +81,6 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
         "identifier": "[JUMBF_URI]"
       },
       "ingredients": [
-        {
-          "title": "C.jpg",
-          "format": "image/jpeg",
-          "instance_id": [XMP_ID]",
-          "thumbnail": {
-            "format": "image/jpeg",
-            "identifier": "[JUMBF_URI]"
-          },
-          "relationship": "parentOf",
-          "active_manifest": "[MANIFEST_URN]"
-        },
         {
           "title": "earth_apollo17.jpg",
           "format": "image/jpeg",
@@ -116,6 +112,17 @@ expression: "&ManifestStore::from_file(output_path.join(\"C.c2pa\"))?"
             "identifier": "[JUMBF_URI]"
           },
           "relationship": "componentOf"
+        },
+        {
+          "title": "C.jpg",
+          "format": "image/jpeg",
+          "instance_id": [XMP_ID]",
+          "thumbnail": {
+            "format": "image/jpeg",
+            "identifier": "[JUMBF_URI]"
+          },
+          "relationship": "parentOf",
+          "active_manifest": "[MANIFEST_URN]"
         }
       ],
       "assertions": [

--- a/tests/snapshots/test_trust__load_trust_from_untrusted_file.snap
+++ b/tests/snapshots/test_trust__load_trust_from_untrusted_file.snap
@@ -5,7 +5,7 @@ info:
   args:
     - view
     - manifest
-    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/C.jpg
+    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/signed-images/C.jpg
     - "--trust-anchors"
     - /Users/nicky/Documents/repos/c2patool/tests/fixtures/trust/no-match.pem
     - "--trust-config"
@@ -74,9 +74,9 @@ exit_code: 0
       "explanation": "signing certificate untrusted"
     },
     {
-      "code": "claimSignature.mismatch",
+      "code": "general.error",
       "url": "self#jumbf=/c2pa/contentauth:urn:uuid:a621a5d8-147d-499b-95d7-2eaff1009efc/c2pa.signature",
-      "explanation": "claim signature is not valid"
+      "explanation": "claim signature is not valid: CoseCertUntrusted"
     }
   ]
 }

--- a/tests/snapshots/test_trust__load_trust_from_untrusted_url.snap
+++ b/tests/snapshots/test_trust__load_trust_from_untrusted_url.snap
@@ -5,11 +5,11 @@ info:
   args:
     - view
     - manifest
-    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/C.jpg
-    - "--trust-anchors"
-    - "http://127.0.0.1:61755/trust/anchors.pem"
-    - "--trust-config"
-    - "http://127.0.0.1:61755/trust/store.cfg"
+    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/signed-images/C.jpg
+    - "--trust-anchors-url"
+    - "http://127.0.0.1:60604/trust/anchors.pem"
+    - "--trust-config-url"
+    - "http://127.0.0.1:60604/trust/store.cfg"
 ---
 success: true
 exit_code: 0
@@ -74,9 +74,9 @@ exit_code: 0
       "explanation": "signing certificate untrusted"
     },
     {
-      "code": "claimSignature.mismatch",
+      "code": "general.error",
       "url": "self#jumbf=/c2pa/contentauth:urn:uuid:a621a5d8-147d-499b-95d7-2eaff1009efc/c2pa.signature",
-      "explanation": "claim signature is not valid"
+      "explanation": "claim signature is not valid: CoseCertUntrusted"
     }
   ]
 }

--- a/tests/snapshots/test_trust__load_trust_from_untrusted_url_env.snap
+++ b/tests/snapshots/test_trust__load_trust_from_untrusted_url_env.snap
@@ -5,10 +5,10 @@ info:
   args:
     - view
     - manifest
-    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/C.jpg
+    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/signed-images/C.jpg
   env:
-    C2PATOOL_TRUST_ANCHORS: "http://127.0.0.1:61761/trust/anchors.pem"
-    C2PATOOL_TRUST_CONFIG: "http://127.0.0.1:61761/trust/store.cfg"
+    C2PATOOL_TRUST_ANCHORS_URL: "http://127.0.0.1:60600/trust/anchors.pem"
+    C2PATOOL_TRUST_CONFIG_URL: "http://127.0.0.1:60600/trust/store.cfg"
 ---
 success: true
 exit_code: 0
@@ -73,9 +73,9 @@ exit_code: 0
       "explanation": "signing certificate untrusted"
     },
     {
-      "code": "claimSignature.mismatch",
+      "code": "general.error",
       "url": "self#jumbf=/c2pa/contentauth:urn:uuid:a621a5d8-147d-499b-95d7-2eaff1009efc/c2pa.signature",
-      "explanation": "claim signature is not valid"
+      "explanation": "claim signature is not valid: CoseCertUntrusted"
     }
   ]
 }

--- a/tests/snapshots/test_view__view_certs.snap
+++ b/tests/snapshots/test_view__view_certs.snap
@@ -5,7 +5,7 @@ info:
   args:
     - view
     - certs
-    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/C.jpg
+    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/signed-images/C.jpg
 ---
 success: true
 exit_code: 0
@@ -124,8 +124,5 @@ zR6jFN/gUe42P1lIOfcjLZAM1GHixtjP5gLAp6sJS8X05O8xQRBtnOsEwNLj5w0y
 MAdtwAzT/Vfv7b08qfx4FfQPFmtjvdu4s82gNatxSA==
 -----END CERTIFICATE-----
 
-
-
-Certificate Status: Good, next update: "[TIMESTAMP2]"
 
 ----- stderr -----

--- a/tests/snapshots/test_view__view_tree.snap
+++ b/tests/snapshots/test_view__view_tree.snap
@@ -5,13 +5,13 @@ info:
   args:
     - view
     - tree
-    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/C.jpg
+    - /Users/nicky/Documents/repos/c2patool/tests/fixtures/signed-images/C.jpg
 ---
 success: true
 exit_code: 0
 ----- stdout -----
-Tree View:
- Asset:C.jpg, Manifest:contentauth:urn:uuid:a621a5d8-147d-499b-95d7-2eaff1009efc
+Asset:C.jpg
+├── Manifest:contentauth:urn:uuid:a621a5d8-147d-499b-95d7-2eaff1009efc
 ├── Assertion:c2pa.thumbnail.claim.jpeg
 ├── Assertion:stds.schema-org.CreativeWork
 ├── Assertion:c2pa.actions

--- a/tests/test_extract.rs
+++ b/tests/test_extract.rs
@@ -12,10 +12,10 @@
 
 mod common;
 
-use std::fs;
+use std::fs::{self, File};
 
 use anyhow::Result;
-use c2pa::ManifestStore;
+use c2pa::Reader;
 use common::{cli, test_img_path, TEST_IMAGE_WITH_MANIFEST_FORMAT};
 use insta::assert_json_snapshot;
 use insta_cmd::assert_cmd_snapshot;
@@ -52,18 +52,14 @@ fn test_extract_manifest_binary() -> Result<()> {
         .arg(&output_path)
         .arg("--binary"));
 
-    assert_json_snapshot!(ManifestStore::from_manifest_and_asset_bytes(
-        &fs::read(output_path)?,
-        TEST_IMAGE_WITH_MANIFEST_FORMAT,
-        &fs::read(test_img_path())?
+    assert_json_snapshot!(unescape_json(
+        &Reader::from_manifest_data_and_stream(
+            &fs::read(&output_path)?,
+            TEST_IMAGE_WITH_MANIFEST_FORMAT,
+            &File::open(test_img_path())?
+        )?
+        .json()
     )?);
-    // TODO: need json without formatting from c2pa-rs
-    // assert_json_snapshot!(Reader::from_manifest_data_and_stream(
-    //     &fs::read(output_path)?,
-    //     TEST_IMAGE_WITH_MANIFEST_FORMAT,
-    //     &File::open(test_img_path())?
-    // )?
-    // .json());
 
     Ok(())
 }

--- a/tests/test_extract.rs
+++ b/tests/test_extract.rs
@@ -57,6 +57,13 @@ fn test_extract_manifest_binary() -> Result<()> {
         TEST_IMAGE_WITH_MANIFEST_FORMAT,
         &fs::read(test_img_path())?
     )?);
+    // TODO: need json without formatting from c2pa-rs
+    // assert_json_snapshot!(Reader::from_manifest_data_and_stream(
+    //     &fs::read(output_path)?,
+    //     TEST_IMAGE_WITH_MANIFEST_FORMAT,
+    //     &File::open(test_img_path())?
+    // )?
+    // .json());
 
     Ok(())
 }

--- a/tests/test_sign.rs
+++ b/tests/test_sign.rs
@@ -13,8 +13,8 @@
 mod common;
 
 use anyhow::Result;
-use c2pa::ManifestStore;
-use common::{cli, fixture_path, test_img_path, TEST_IMAGE_WITH_MANIFEST};
+use c2pa::Reader;
+use common::{cli, fixture_path, test_img_path, unescape_json, TEST_IMAGE_WITH_MANIFEST};
 use insta::{assert_json_snapshot, Settings};
 use insta_cmd::assert_cmd_snapshot;
 
@@ -35,7 +35,7 @@ fn test_sign() -> Result<()> {
 
     apply_sorted_output!();
 
-    assert_json_snapshot!(ManifestStore::from_file(output_path)?);
+    assert_json_snapshot!(unescape_json(&Reader::from_file(output_path)?.json())?);
 
     Ok(())
 }
@@ -62,8 +62,12 @@ fn test_sign_multiple() -> Result<()> {
 
     apply_sorted_output!();
 
-    assert_json_snapshot!(ManifestStore::from_file(output_path.join(input1_name))?);
-    assert_json_snapshot!(ManifestStore::from_file(output_path.join(input2_name))?);
+    assert_json_snapshot!(unescape_json(
+        &Reader::from_file(output_path.join(input1_name))?.json()
+    )?);
+    assert_json_snapshot!(unescape_json(
+        &Reader::from_file(output_path.join(input2_name))?.json()
+    )?);
 
     Ok(())
 }
@@ -87,7 +91,7 @@ fn test_sign_parent() -> Result<()> {
 
     apply_sorted_output!();
 
-    assert_json_snapshot!(ManifestStore::from_file(output_path)?);
+    assert_json_snapshot!(unescape_json(&Reader::from_file(output_path)?.json())?);
 
     Ok(())
 }
@@ -110,8 +114,12 @@ fn test_sign_sidecar() -> Result<()> {
 
     apply_sorted_output!();
 
-    assert_json_snapshot!(&ManifestStore::from_file(output_path.join("C.jpg"))?);
-    assert_json_snapshot!(&ManifestStore::from_file(output_path.join("C.c2pa"))?);
+    assert_json_snapshot!(unescape_json(
+        &Reader::from_file(output_path.join("C.jpg"))?.json()
+    )?);
+    assert_json_snapshot!(unescape_json(
+        &Reader::from_file(output_path.join("C.c2pa"))?.json()
+    )?);
 
     Ok(())
 }


### PR DESCRIPTION
## Changes in this pull request
Migrates to c2pa-rs unstable API.

### Blockers
TODOs are scattered around with various blockers and changes. Here's a list of some of the critical ones:
- [x] Need methods to iterate all manifests and all resources in manifest contentauth/c2pa-rs/pull/482
- [x] Need method to set builder base path [ok-nick/builder_base_path](https://github.com/contentauth/c2pa-rs/tree/ok-nick/builder_base_path)
- [x] Need method to normalize identifiers (preferably a struct/enum wrapping them)
- [x] Need methods for fetching manifest certificates
- [x] Need methods for fetching manifest tree structure

### Non-critical Blockers
Check the TODOs for more information.
- [ ] Converting structs (Ingredient, Manifest, Reader, etc.) to json shouldn't pretty print (include \n, etc.)
  * Rust has a format such as `{:#?}` for explicitly requesting pretty print
  * The reason this is useful is when we need to convert the json string back to struct and the formatting is interfering
- [ ] Constructing builder and ingredients is difficult and often results in repeated serialization and I/O
  * It's also confusing to have to operate on the ingredient returned by add_ingredient (like for setting base paths)

## Additional Features
* Added `--unknown` flag when extracting resources to extract unstandardized labeled data (in addition to standardized labels such as thumbnails)
* Added `--no-embed` flag when signing to not embed a manifest in the asset.
* WIP: Add `--detailed` flag to `view tree` to view URNs (for possible use with redactions)

## Checklist
- [ ] This PR represents a single feature, fix, or change.
- [ ] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
