### PR TITLE
Match c2pa-rs minimum toolchain version and test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ windows-latest, macos-latest, ubuntu-latest ]
-        rust_version: [ stable ]
+        rust_version: [ stable, 1.74.0 ]
 
     steps:
       - name: Checkout repository

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ documentation = "https://opensource.contentauthenticity.org/docs/c2patool"
 readme = "README.md"
 keywords = ["c2pa", "xmp", "metadata"]
 edition = "2018"
-rust-version = "1.61.0"
+rust-version = "1.74.0"
 homepage = "https://contentauthenticity.org"
 repository = "https://github.com/contentauth/c2patool"
 


### PR DESCRIPTION
## Changes in this pull request
Matches c2pa-rs minimum toolchain version (1.74.0) and tests that version in CI.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
