### PR TITLE
Initial fragment support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,6 +633,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
+name = "bytemuck"
+version = "1.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773d90827bc3feecfb67fab12e24de0749aad83c74b9504ecde46237b5cd24e2"
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -655,7 +661,9 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "c2pa"
-version = "0.33.3"
+version = "0.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a58cfe2a1fb0ff7a770dea52bcda16dbfd2b218019b6b56a2d496facee72b35"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -679,12 +687,14 @@ dependencies = [
  "getrandom",
  "hex",
  "id3",
+ "image",
  "img-parts",
  "instant",
  "jfifdump",
  "js-sys",
  "lazy_static",
  "log",
+ "lopdf",
  "memchr",
  "mp4",
  "multibase",
@@ -845,6 +855,12 @@ name = "clap_lex"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -1394,6 +1410,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1935,6 +1960,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
+]
+
+[[package]]
 name = "img-parts"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2070,12 @@ name = "jfifdump"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "326647c83ea8fb213e58a272f11d4569611277d8730f9905a59fba9d30b12c05"
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -2165,6 +2210,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2245,31 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
+
+[[package]]
+name = "lopdf"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c8e1b6184b1b32ea5f72f572ebdc40e5da1d2921fa469947ff7c480ad1f85a"
+dependencies = [
+ "chrono",
+ "encoding_rs",
+ "flate2",
+ "itoa",
+ "linked-hash-map",
+ "log",
+ "md5",
+ "nom",
+ "rayon",
+ "time",
+ "weezl",
+]
+
+[[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -2229,6 +2305,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -2742,6 +2819,19 @@ name = "pkg-config"
 version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
+
+[[package]]
+name = "png"
+version = "0.17.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
+dependencies = [
+ "bitflags 1.3.2",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.7.4",
+]
 
 [[package]]
 name = "png_pong"
@@ -4071,9 +4161,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.0"
+version = "2.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
+checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4240,6 +4330,12 @@ checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
+
+[[package]]
+name = "weezl"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,9 +116,9 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "arrayvec"
-version = "0.7.4"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ascii-canvas"
@@ -242,9 +242,9 @@ dependencies = [
 
 [[package]]
 name = "async-generic"
-version = "0.1.2"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86bc01d15ca67ec7653924057aa97c30de62d06a24e6834387eba6c72c8318e7"
+checksum = "80548ada198a0260b9e9d09dfce57919d6c239c3aae2309b3efc1f89096a0e29"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -547,9 +547,9 @@ dependencies = [
 
 [[package]]
 name = "bitvec-nom2"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4863ce31b7ff8812568eaffe956024c824d845a1f9f08c329706166c357cae53"
+checksum = "d988fcc40055ceaa85edc55875a08f8abd29018582647fd82ad6128dba14a5f0"
 dependencies = [
  "bitvec",
  "nom",
@@ -633,12 +633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
-name = "bytemuck"
-version = "1.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,9 +655,7 @@ checksum = "8318a53db07bb3f8dca91a600466bdb3f2eaadeedfdbcf02e1accbad9271ba50"
 
 [[package]]
 name = "c2pa"
-version = "0.33.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75204624c8d637aef354a01df16b52fa63c833cd3766022f15e0d34dd4b15830"
+version = "0.33.3"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -687,14 +679,12 @@ dependencies = [
  "getrandom",
  "hex",
  "id3",
- "image",
  "img-parts",
  "instant",
  "jfifdump",
  "js-sys",
  "lazy_static",
  "log",
- "lopdf",
  "memchr",
  "mp4",
  "multibase",
@@ -744,6 +734,7 @@ dependencies = [
  "c2pa",
  "clap",
  "env_logger",
+ "glob",
  "httpmock",
  "log",
  "mockall",
@@ -856,12 +847,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
-name = "color_quant"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
-
-[[package]]
 name = "colorchoice"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -932,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "const_panic"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6051f239ecec86fde3410901ab7860d458d160371533842974fc61f96d15879b"
+checksum = "7782af8f90fe69a4bb41e460abe1727d493403d8b2cc43201a3a3e906b24379f"
 
 [[package]]
 name = "constant_time_eq"
@@ -1409,15 +1394,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f9bfee30e4dedf0ab8b422f03af778d9612b63f502710fc500a334ebe2de645"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1431,12 +1407,12 @@ checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
-version = "1.0.31"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.7.4",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -1608,6 +1584,12 @@ name = "gimli"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+
+[[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "gloo-timers"
@@ -1953,20 +1935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.24.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
-dependencies = [
- "bytemuck",
- "byteorder",
- "color_quant",
- "jpeg-decoder",
- "num-traits",
- "png",
-]
-
-[[package]]
 name = "img-parts"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2063,12 +2031,6 @@ name = "jfifdump"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "326647c83ea8fb213e58a272f11d4569611277d8730f9905a59fba9d30b12c05"
-
-[[package]]
-name = "jpeg-decoder"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -2203,12 +2165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2238,31 +2194,6 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 dependencies = [
  "value-bag",
 ]
-
-[[package]]
-name = "lopdf"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07c8e1b6184b1b32ea5f72f572ebdc40e5da1d2921fa469947ff7c480ad1f85a"
-dependencies = [
- "chrono",
- "encoding_rs",
- "flate2",
- "itoa",
- "linked-hash-map",
- "log",
- "md5",
- "nom",
- "rayon",
- "time",
- "weezl",
-]
-
-[[package]]
-name = "md5"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
@@ -2298,7 +2229,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
 dependencies = [
  "adler",
- "simd-adler32",
 ]
 
 [[package]]
@@ -2814,19 +2744,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
-name = "png"
-version = "0.17.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06e4b0d3d1312775e782c86c91a111aa1f910cbb65e1337f9975b5f9a554b5e1"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide 0.7.4",
-]
-
-[[package]]
 name = "png_pong"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,7 +2915,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9b0d03fbc7d2dcfdd35086c43ce30ac5ff62ed7eff4397e4f4f2995a2b0e2a"
 dependencies = [
- "arrayvec 0.7.4",
+ "arrayvec 0.7.6",
  "bitvec",
  "bitvec-nom2",
  "bytes",
@@ -3249,9 +3166,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
@@ -4323,12 +4240,6 @@ checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
 ]
-
-[[package]]
-name = "weezl"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,14 +22,15 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-c2pa = { version = "0.33.2", features = [
-	"fetch_remote_manifests",
-	"file_io",
-	"add_thumbnails",
-	"pdf",
-] }
+#c2pa = { version = "0.33.2", features = [
+#	"fetch_remote_manifests",
+#	"file_io",
+#	"add_thumbnails",
+#	"pdf",
+#] }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"
+glob = "0.3.1"
 log = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_derive = "1.0"
@@ -39,6 +40,10 @@ pem = "3.0.3"
 openssl = { version = "0.10.61", features = ["vendored"] }
 reqwest = { version = "0.12.4", features = ["blocking"] }
 url = "2.5.0"
+
+[dependencies.c2pa]
+path = "../c2pa-rs/sdk"
+features = ["fetch_remote_manifests", "file_io"]
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,12 +22,12 @@ repository = "https://github.com/contentauth/c2patool"
 
 [dependencies]
 anyhow = "1.0"
-#c2pa = { version = "0.33.2", features = [
-#	"fetch_remote_manifests",
-#	"file_io",
-#	"add_thumbnails",
-#	"pdf",
-#] }
+c2pa = { version = "0.34.0", features = [
+	"fetch_remote_manifests",
+	"file_io",
+	"add_thumbnails",
+	"pdf",
+] }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"
 glob = "0.3.1"
@@ -40,10 +40,6 @@ pem = "3.0.3"
 openssl = { version = "0.10.61", features = ["vendored"] }
 reqwest = { version = "0.12.4", features = ["blocking"] }
 url = "2.5.0"
-
-[dependencies.c2pa]
-path = "../c2pa-rs/sdk"
-features = ["fetch_remote_manifests", "file_io"]
 
 [dev-dependencies]
 assert_cmd = "2.0.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,7 +25,7 @@ use std::{
 };
 
 use anyhow::{anyhow, bail, Context, Result};
-use c2pa::{Error, Ingredient, Manifest, ManifestStore, ManifestStoreReport};
+use c2pa::{Error, Ingredient, Manifest, ManifestStore, ManifestStoreReport, Signer};
 use clap::{Parser, Subcommand};
 use log::debug;
 use serde::Deserialize;
@@ -163,6 +163,14 @@ enum Commands {
         #[arg(long = "trust_config", env="C2PATOOL_TRUST_CONFIG", value_parser = parse_resource_string)]
         trust_config: Option<TrustResource>,
     },
+    /// Sub-command to add manifest to fragmented BMFF content
+    Fragment {
+        /// Glob pattern to find the fragments of the video. The path is automatically set to be the same as
+        /// the init segment. The glob pattern should only match fragment file names (e.g. "myfile_abc*.m4s"
+        /// to match [myfile_abc1.m4s, myfile_abc21.m4s, ...] )
+        #[arg(long = "fragments_glob")]
+        fragments_glob: Option<PathBuf>,
+    },
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -287,7 +295,7 @@ fn configure_sdk(args: &CliArgs) -> Result<()> {
                 enable_trust_checks = true;
             }
         }
-        None => {}
+        _ => {}
     }
 
     // if any trust setting is provided enable the trust checks
@@ -306,6 +314,98 @@ fn configure_sdk(args: &CliArgs) -> Result<()> {
     }
 
     Ok(())
+}
+
+fn sign_fragmented(
+    manifest: &mut Manifest,
+    signer: &dyn Signer,
+    init_pattern: &PathBuf,
+    frag_pattern: &PathBuf,
+    output_path: &PathBuf,
+) -> Result<()> {
+    // search folders for init segments
+    let ip = init_pattern.to_str().ok_or(c2pa::Error::OtherError(
+        "could not parse source pattern".into(),
+    ))?;
+    let inits = glob::glob(ip)
+        .map_err(|_e| c2pa::Error::OtherError("could not process glob pattern".into()))?;
+    let mut count = 0;
+    for init in inits {
+        match init {
+            Ok(p) => {
+                let mut fragments = Vec::new();
+                let init_dir = p.parent().unwrap();
+                let seg_glob = init_dir.join(frag_pattern); // segment match pattern
+
+                // grab the fragments that go with this init segment
+                for seg in glob::glob(seg_glob.to_str().unwrap()).unwrap().flatten() {
+                    fragments.push(seg);
+                }
+
+                println!("Adding manifest to: {:?}", p);
+                let new_output_path = output_path.join(init_dir.file_name().unwrap());
+                manifest.embed_to_bmff_fragmented(&p, &fragments, &new_output_path, signer)?;
+
+                count += 1;
+            }
+            Err(_) => bail!("bad path to init segment"),
+        }
+    }
+    if count == 0 {
+        println!("No files matching pattern: {}", ip);
+    }
+    Ok(())
+}
+
+fn verify_fragmented(
+    init_pattern: &PathBuf,
+    frag_pattern: &PathBuf,
+) -> Result<Vec<ManifestStore>> {
+    let mut stores = Vec::new();
+
+    let ip = init_pattern.to_str().ok_or(c2pa::Error::OtherError(
+        "could not parse source pattern".into(),
+    ))?;
+    let inits = glob::glob(ip)
+        .map_err(|_e| c2pa::Error::OtherError("could not process glob pattern".into()))?;
+    let mut count = 0;
+
+    // search folders for init segments
+    for init in inits {
+        match init {
+            Ok(p) => {
+                let mut fragments = Vec::new();
+                let init_dir = p.parent().unwrap();
+                let seg_glob = init_dir.join(frag_pattern); // segment match pattern
+
+                // grab the fragments that go with this init segment
+                for seg in glob::glob(seg_glob.to_str().unwrap()).unwrap().flatten() {
+                    fragments.push(seg);
+                }
+
+                println!("Verifying manifest: {:?}", p);
+                let store = ManifestStore::from_fragments(p, &fragments, true)?;
+                if let Some(vs) = store.validation_status() {
+                    if let Some(e) =  vs.iter().find(|v| !v.passed()) 
+                    {
+                        println!("Error validating segments: {:?}", e);
+                        return Ok(stores);
+                    }
+                }
+
+                stores.push(store);
+
+                count += 1;
+            }
+            Err(_) => bail!("bad path to init segment"),
+        }
+    }
+
+    if count == 0 {
+        println!("No files matching pattern: {}", ip);
+    }
+
+    Ok(stores)
 }
 
 fn main() -> Result<()> {
@@ -331,6 +431,17 @@ fn main() -> Result<()> {
     if args.tree {
         ManifestStoreReport::dump_tree(path)?;
         return Ok(());
+    }
+
+    let is_fragment = if let Some(Commands::Fragment { fragments_glob: _ }) = &args.command {
+        true
+    } else {
+        false
+    };
+
+    // make sure path is not a glob when not fragmented
+    if !args.path.is_file() && !is_fragment {
+        bail!("glob patterns only allowed when using \"fragment\" command")
     }
 
     // configure the SDK
@@ -413,7 +524,7 @@ fn main() -> Result<()> {
 
         // If the source file has a manifest store, and no parent is specified treat the source as a parent.
         // note: This could be treated as an update manifest eventually since the image is the same
-        if manifest.parent().is_none() {
+        if manifest.parent().is_none() && !is_fragment {
             let source_ingredient = Ingredient::from_file(&args.path)?;
             if source_ingredient.manifest_data().is_some() {
                 manifest.set_parent(source_ingredient)?;
@@ -431,49 +542,82 @@ fn main() -> Result<()> {
         }
 
         if let Some(output) = args.output {
-            if ext_normal(&output) != ext_normal(&args.path) {
-                bail!("Output type must match source type");
-            }
-            if output.exists() && !args.force {
-                bail!("Output already exists, use -f/force to force write");
-            }
+            // fragmented embedding
+            if let Some(Commands::Fragment { fragments_glob }) = &args.command {
+                if output.exists() && !output.is_dir() {
+                    bail!("Output cannot point to existing file, must be a directory");
+                }
 
-            if output.file_name().is_none() {
-                bail!("Missing filename on output");
-            }
-            if output.extension().is_none() {
-                bail!("Missing extension output");
-            }
+                let signer = if let Some(signer_process_name) = args.signer_path {
+                    let cb_config = CallbackSignerConfig::new(&sign_config, args.reserve_size)?;
 
-            let signer = if let Some(signer_process_name) = args.signer_path {
-                let cb_config = CallbackSignerConfig::new(&sign_config, args.reserve_size)?;
+                    let process_runner = Box::new(ExternalProcessRunner::new(
+                        cb_config.clone(),
+                        signer_process_name,
+                    ));
+                    let signer = CallbackSigner::new(process_runner, cb_config);
 
-                let process_runner = Box::new(ExternalProcessRunner::new(
-                    cb_config.clone(),
-                    signer_process_name,
-                ));
-                let signer = CallbackSigner::new(process_runner, cb_config);
+                    Box::new(signer)
+                } else {
+                    sign_config.signer()?
+                };
 
-                Box::new(signer)
+                if let Some(fg) = &fragments_glob {
+                    return sign_fragmented(
+                        &mut manifest,
+                        signer.as_ref(),
+                        &args.path,
+                        fg,
+                        &output,
+                    );
+                } else {
+                    bail!("fragments_glob must be set");
+                }
             } else {
-                sign_config.signer()?
-            };
+                if ext_normal(&output) != ext_normal(&args.path) {
+                    bail!("Output type must match source type");
+                }
+                if output.exists() && !args.force {
+                    bail!("Output already exists, use -f/force to force write");
+                }
 
-            manifest
-                .embed(&args.path, &output, signer.as_ref())
-                .context("embedding manifest")?;
+                if output.file_name().is_none() {
+                    bail!("Missing filename on output");
+                }
+                if output.extension().is_none() {
+                    bail!("Missing extension output");
+                }
 
-            // generate a report on the output file
-            if args.detailed {
-                println!(
-                    "{}",
-                    ManifestStoreReport::from_file(&output).map_err(special_errs)?
-                );
-            } else {
-                println!(
-                    "{}",
-                    ManifestStore::from_file(&output).map_err(special_errs)?
-                )
+                let signer = if let Some(signer_process_name) = args.signer_path {
+                    let cb_config = CallbackSignerConfig::new(&sign_config, args.reserve_size)?;
+
+                    let process_runner = Box::new(ExternalProcessRunner::new(
+                        cb_config.clone(),
+                        signer_process_name,
+                    ));
+                    let signer = CallbackSigner::new(process_runner, cb_config);
+
+                    Box::new(signer)
+                } else {
+                    sign_config.signer()?
+                };
+
+                manifest
+                    .embed(&args.path, &output, signer.as_ref())
+                    .context("embedding manifest")?;
+
+                // generate a report on the output file
+                if args.detailed {
+                    println!(
+                        "{}",
+                        ManifestStoreReport::from_file(&output).map_err(special_errs)?
+                    );
+                } else {
+                    println!(
+                        "{}",
+                        ManifestStore::from_file(&output).map_err(special_errs)?
+                    )
+                }
             }
         } else {
             bail!("Output path required with manifest definition")
@@ -524,10 +668,26 @@ fn main() -> Result<()> {
             ManifestStoreReport::from_file(&args.path).map_err(special_errs)?
         )
     } else {
-        println!(
-            "{}",
-            ManifestStore::from_file(&args.path).map_err(special_errs)?
-        )
+        if let Some(Commands::Fragment { fragments_glob }) = &args.command {
+            if let Some(fg) = &fragments_glob {
+                let stores = verify_fragmented(&args.path, fg)?;
+                if stores.len() == 1 {
+                    println!("{}", stores[0]);
+                } else {
+                    println!("{} Init manifests validated", stores.len());
+                }
+            } else {
+                println!(
+                    "{}",
+                    ManifestStore::from_file(&args.path).map_err(special_errs)?
+                )
+            }
+        } else {
+            println!(
+                "{}",
+                ManifestStore::from_file(&args.path).map_err(special_errs)?
+            )
+        }
     }
 
     Ok(())


### PR DESCRIPTION
## Changes in this pull request
New commands to add and validate BMFF fragmented assets.  Support for globing to enables processing of complete DASH hierarchies.  

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
