### PR TITLE
chore: Skip CodeCov upload for non-member PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,17 +16,6 @@ on:
     - cron: "30 18 * * 1,4,6" # 1830 UTC every Monday, Thursday, Saturday
 
 jobs:
-  debug:
-    name: Debug context
-    runs-on: ubuntu-latest
-    steps:
-      - name: Debug context
-        env:
-          ASSOC: ${{ github.event.pull_request.author_association }}
-        run: |
-          echo author_association = $ASSOC
-
-      
   tests:
     name: Unit tests
     if: |
@@ -62,7 +51,13 @@ jobs:
           RUST_BACKTRACE: "1"
         run: cargo llvm-cov --bins --all-features --lcov --output-path lcov.info
 
+      # Tokens aren't available for PRs originating from forks,
+      # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
+        if: |
+          github.event.pull_request.author_association == 'COLLABORATOR' ||
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.user.login == 'dependabot[bot]'
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
(We don't have access to the CodeCov token, which means the upload will likely be rate-limited and fail.)
