### PR TITLE
doc: Fix broken link that was causing os site workflow to fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Where:
 
 The tool supports the following subcommands:
 - `trust` [configures trust support](#configuring-trust-support) for certificates on a "known certificate list." With this subcommand, several additional options are available.
-- `fragment` [adds a manifest to fragmented BMFF content]().  With this subcommand, one additional option is available.
+- `fragment` [adds a manifest to fragmented BMFF content](#adding-a-manifest-to-fragmented-bmff-content).  With this subcommand, one additional option is available.
 - `help` displays command line help information.
 
 ### Options


### PR DESCRIPTION
## Changes in this pull request
Internal link in README was missing URL.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
