### PR TITLE
enlarged description of c2pa command-line behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Where:
 - `<PATH>` is the (relative or absolute) file path to the asset to read or embed a manifest into.
 - `[COMMAND]` is one of the optional subcommands: `trust`, `fragment`, or `help`.
 
+By default, c2patool writes a JSON representation of C2PA manifests found in the asset to the standard output. 
+
 ### Subcommands
 
 The tool supports the following subcommands:
@@ -319,6 +321,8 @@ Enable trust support by using the `trust` subcommand, as follows:
 ```
 c2patool [path] trust [OPTIONS]
 ```
+
+When the `trust` subcommand is supplied, should c2patool encounter a problem with validating any of the claims in the asset, its JSON output will contain a `validation_status` field whose value is an array of objects, each describing a validation problem.
 
 ### Additional options
 


### PR DESCRIPTION
## Changes in this pull request
1. Describes the default behavior of the c2pa command line.
2. Describes the behavior when `trust` is in force and validation problems are found.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [x] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
