### PR TITLE
chore: uploads sbom as artifact

### DIFF
--- a/.github/workflows/publish-and-release.yml
+++ b/.github/workflows/publish-and-release.yml
@@ -126,9 +126,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        rust_version: [stable]
-        experimental: [false]
+        os: [ macos-latest, ubuntu-latest, windows-latest ]
+        rust_version: [ stable ]
+        experimental: [ false ]
         include:
           - os: macos-latest
             artifact_name: c2patool_mac_universal.zip
@@ -152,6 +152,12 @@ jobs:
           toolchain: ${{ matrix.rust_version }}
           components: llvm-tools-preview
 
+      - name: Install cargo-sbom
+        uses: baptiste0928/cargo-install@v3
+        with:
+          crate: cargo-sbom
+          version: '0.9.1'
+
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
 
@@ -166,3 +172,16 @@ jobs:
           asset_name: ${{ matrix.uploaded_asset_name }}
           tag: ${{ needs.repo-prep.outputs.new-tag }}
           overwrite: true
+
+      - name: Generate SBOM
+        run: cargo sbom > c2patool.${{ matrix.os }}.sbom.json
+
+      - name: Upload SBOM to Github
+        uses: svenstaro/upload-release-action@v1-release
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: c2patool.${{ matrix.os }}.sbom.json
+          asset_name: c2patool-${{ needs.repo-prep.outputs.new-tag }}-sbom.json
+          tag: ${{ needs.repo-prep.outputs.new-tag }}
+          overwrite: true
+

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,9 +628,9 @@ checksum = "428d9aa8fbc0670b7b8d6030a7fadd0f86151cae55e4dbbece15f3780a3dfaf3"
 
 [[package]]
 name = "c2pa"
-version = "0.37.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5cb9c3ba71a4979f7d5050c50c2e33c01ca9ee7c4657a7ec50e8644ac9e052"
+checksum = "bbe969c48b165e38e646575000e8f3fe1bfd559f9ec7aefb904da5b8aa5ea83a"
 dependencies = [
  "asn1-rs 0.5.2",
  "async-generic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,8 +9,8 @@ version = "0.9.12"
 
 description = "Tool for displaying and creating C2PA manifests."
 authors = [
-	"Gavin Peacock <gpeacock@adobe.com>",
-	"Maurice Fisher <mfisher@adobe.com>",
+    "Gavin Peacock <gpeacock@adobe.com>",
+    "Maurice Fisher <mfisher@adobe.com>",
 ]
 license = "MIT OR Apache-2.0"
 documentation = "https://opensource.contentauthenticity.org/docs/c2patool"
@@ -23,10 +23,10 @@ repository = "https://github.com/contentauth/c2patool"
 [dependencies]
 anyhow = "1.0"
 c2pa = { version = "0.37.0", features = [
-	"fetch_remote_manifests",
-	"file_io",
-	"add_thumbnails",
-	"pdf",
+    "fetch_remote_manifests",
+    "file_io",
+    "add_thumbnails",
+    "pdf",
 ] }
 clap = { version = "4.5.10", features = ["derive", "env"] }
 env_logger = "0.11.4"

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ yanked = "deny"
 ignore = [
   "RUSTSEC-2021-0127", # serde_cbor
   "RUSTSEC-2023-0071", # rsa Marvin Attack: (https://jira.corp.adobe.com/browse/CAI-5104)
+  "RUSTSEC-2024-0384", # instant (https://github.com/contentauth/c2pa-rs/issues/663)
 ]
 # Deny multiple versions unless explicitly skipped.
 [bans]


### PR DESCRIPTION
* Uploads a **software bill of materials** for c2patool for each of our supported OSs during a release
* Adds `Instant` to our `deny.toml` ignore setting. This can be removed when https://github.com/contentauth/c2pa-rs/issues/663 is done and released. 