### PR TITLE
docs: Fix dangling contentauth/c2pa-rs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ If you're using another OS or don't want to use Homebrew, install a prebuilt bin
 3. Download and extract the archive file.
 4. Copy the `c2patool` executable file to a location on your `PATH`.
 
+> [!NOTE]
+> Looking for an older version? `c2patool` used to be part of the `c2pa-rs` monorepo. Releases `v0.27.15` and earlier live on [c2pa-rs's Releases page](https://github.com/contentauth/c2pa-rs/releases) instead, tagged `c2patool-vX.Y.Z`.
+
 
 After installing, confirm that you can run the tool by entering a command such as:
 ```

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are using macOS, you can install C2PA Tool using Homebrew:
 
 If you're using another OS or don't want to use Homebrew, install a prebuilt binary of C2PA Tool:
 
-1. Go to the [Releases page and filter for c2patool](https://github.com/contentauth/c2pa-rs/releases?q=c2patool). 
+1. Go to the [Releases page](https://github.com/contentauth/c2patool/releases). 
 2. Under **Assets**, click on the archive file for your operating system:
    - MacOS: `c2patool-vx.y.z-universal-apple-darwin.zip`
    - Windows: `c2patool-vx.y.z-x86_64-pc-windows-msvc.zip`
@@ -53,11 +53,11 @@ c2patool -h
 
 When running a prebuilt binary, you may need to set execution permission for the tool on your system. For macOS, see [If you want to open an app that hasn’t been notarized or is from an unidentified developer](https://support.apple.com/en-us/102445#openanyway).
 
-NOTE: You also may want to get some of the example files provided in the repository `sample` directory.   To do so, clone the repository with `git clone https://github.com/contentauth/c2pa-rs.git`.
+NOTE: You also may want to get some of the example files provided in the repository `sample` directory.   To do so, clone the repository with `git clone https://github.com/contentauth/c2patool.git`.
 
 ### Installing from source
 
-Instead of installing a prebuilt binary, you can [build the project from source](https://github.com/contentauth/c2pa-rs/blob/main/cli/docs/project-contributions.md#building-from-source).
+Instead of installing a prebuilt binary, you can [build the project from source](https://github.com/contentauth/c2patool/blob/main/docs/project-contributions.md#building-from-source).
 
 ### Upgrading
 
@@ -67,6 +67,6 @@ To display the version of C2PA Tool that you have, enter this command:
 c2patool -V
 ```
 
-The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page filtered for c2patool](https://github.com/contentauth/c2pa-rs/releases?q=c2patool).  
+The tool will display the version installed. Compare the version number displayed with the latest release version shown in the [repository releases page](https://github.com/contentauth/c2patool/releases).  
 
 If you don't have the latest version, simply reinstall C2PA Tool to get the latest version.

--- a/docs/cawg_x509_signing.md
+++ b/docs/cawg_x509_signing.md
@@ -24,7 +24,7 @@ If `sign_cert` and `private_key` are absent from `[cawg_x509_signer]`, no CAWG i
 
 Supported algorithm values: `ps256`, `ps384`, `ps512`, `es256`, `es384`, `es512`, `ed25519`. The algorithm must be compatible with the private key and signing certificate. For more information, see [Signing and certificates](https://opensource.contentauthenticity.org/docs/signing/).
 
-An example settings file is provided in the [c2patool repo sample folder](https://github.com/contentauth/c2pa-rs/tree/main/cli/tests/fixtures/trust/cawg_sign_settings.toml).
+An example settings file is provided in the [c2patool repo sample folder](https://github.com/contentauth/c2patool/tree/main/tests/fixtures/trust/cawg_sign_settings.toml).
 
 To sign an asset using this method:
 

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -56,7 +56,7 @@ The following manifest properties are specific to C2PA Tool and used for signing
 
 ## Example
 
-The example below is a minimal manifest definition that uses a default testing certificate in the [sample folder](https://github.com/contentauth/c2pa-rs/tree/main/cli/sample) that are also built into the `c2patool` binary.
+The example below is a minimal manifest definition that uses a default testing certificate in the [sample folder](https://github.com/contentauth/c2patool/tree/main/sample) that are also built into the `c2patool` binary.
 
 > [!NOTE]
 > When you don't specify a key or certificate in the manifest `private_key` and `sign_cert` fields, the tool will use the built-in key and cert. You'll see a warning message, since they are meant for development purposes only.

--- a/docs/signing.md
+++ b/docs/signing.md
@@ -132,7 +132,7 @@ tsa_url = "https://timestamp.digicert.com"
 
 Alternatively, put `sign_cert`, `private_key`, and (optionally) `alg` as fields in the manifest JSON, or set the `C2PA_SIGN_CERT` and `C2PA_PRIVATE_KEY` environment variables.
 
-If no signer is configured at all, C2PA Tool uses a built-in test certificate and key from the [`cli/sample` folder](https://github.com/contentauth/c2pa-rs/tree/main/cli/sample). This is only suitable for development.
+If no signer is configured at all, C2PA Tool uses a built-in test certificate and key from the [`cli/sample` folder](https://github.com/contentauth/c2patool/tree/main/sample). This is only suitable for development.
 
 ### CAWG identity assertion
 
@@ -154,7 +154,7 @@ roles = ["creator"]
 
 If `[cawg_x509_signer]` is absent, no CAWG identity assertion is generated.
 
-An example settings file is in the [`cli/tests/fixtures` folder](https://github.com/contentauth/c2pa-rs/tree/main/cli/tests/fixtures/trust/cawg_sign_settings.toml).
+An example settings file is in the [`cli/tests/fixtures` folder](https://github.com/contentauth/c2patool/tree/main/tests/fixtures/trust/cawg_sign_settings.toml).
 
 ## Writing your own signer
 


### PR DESCRIPTION
Fixes links left over from the repo split that pointed at c2pa-rs paths which actually migrated here (sample/, tests/fixtures/, docs/project-contributions.md) and the releases-page filter link. Left the `supported-formats.md` link alone -- that's a genuine c2pa-rs-level doc, not something that moved.

Part of the post-cutover cleanup (see also #304's similar fix, not yet merged).