### PR TITLE
ci: Restore full CI job set for the standalone repo

### DIFF
--- a/.github/workflows/beta-preflight.yml
+++ b/.github/workflows/beta-preflight.yml
@@ -14,34 +14,8 @@ on:
       - beta-preflight
 
 jobs:
-  get-features:
-    name: Get features
-    runs-on: ubuntu-latest
-    outputs:
-      features: ${{ steps.get-features.outputs.features }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
-        with:
-          toolchain: stable
-
-      - name: Get all features (excluding experimental)
-        id: get-features
-        run: |
-          # Union of every workspace feature except `default` and experimental
-          # (`unstable_`) features, so this preflight mirrors a full build
-          # without pulling in experimental code. Experimental features are
-          # exercised only by the non-blocking experimental-features.yml; see
-          # docs/experimental-features.md.
-          FEATURES=$(cargo metadata --format-version=1 --no-deps | jq -r '[.packages[] | .features | keys[]] | unique | map(select(. != "default" and (startswith("unstable_") | not))) | join(" ")')
-          echo "features=$FEATURES" >> "$GITHUB_OUTPUT"
-
   tests-cli:
-    name: Unit tests (c2patool)
-    needs: get-features
+    name: Unit tests
     runs-on: ${{ matrix.os }}
 
     strategy:
@@ -71,4 +45,107 @@ jobs:
       - name: Generate code coverage
         env:
           RUST_BACKTRACE: "1"
-        run: cargo llvm-cov --bins --features "${{ needs.get-features.outputs.features }}" --lcov --output-path lcov.info
+        run: cargo llvm-cov --bins --lcov --output-path lcov.info
+
+  doc-tests:
+    name: Doc tests
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        rust_version: [beta]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: ${{ matrix.rust_version }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run doc tests
+        run: cargo test --doc
+
+  docs-private:
+    name: Internal docs build (private items, warnings denied)
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        rust_version: [beta]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: ${{ matrix.rust_version }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Build internal docs
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: cargo doc --document-private-items --no-deps
+
+  cargo-check:
+    name: Default features build
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        rust_version: [beta]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: ${{ matrix.rust_version }}
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: "`cargo check` with default features"
+        run: cargo check
+
+  clippy_check:
+    name: Clippy
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest, ubuntu-latest]
+        rust_version: [beta]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: ${{ matrix.rust_version }}
+          components: clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -Dwarnings

--- a/.github/workflows/beta-preflight.yml
+++ b/.github/workflows/beta-preflight.yml
@@ -47,31 +47,6 @@ jobs:
           RUST_BACKTRACE: "1"
         run: cargo llvm-cov --bins --lcov --output-path lcov.info
 
-  doc-tests:
-    name: Doc tests
-    runs-on: ${{ matrix.os }}
-
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
-        rust_version: [beta]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
-        with:
-          toolchain: ${{ matrix.rust_version }}
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - name: Run doc tests
-        run: cargo test --doc
-
   docs-private:
     name: Internal docs build (private items, warnings denied)
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/beta-preflight.yml
+++ b/.github/workflows/beta-preflight.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Generate code coverage
         env:
           RUST_BACKTRACE: "1"
-        run: cargo llvm-cov --bins --lcov --output-path lcov.info
+        run: cargo llvm-cov --bins --tests --lcov --output-path lcov.info
 
   docs-private:
     name: Internal docs build (private items, warnings denied)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,22 @@ on:
       - '*-rc*'
 
 jobs:
+  # c2patool ships a Mac/Linux/Windows binary as its core product (and has
+  # real per-OS code, e.g. the `cfg(windows)` windows-sys dependency), unlike
+  # the SDK crate this repo split from, where cross-platform testing is a
+  # separate, more-expensive Tier 1B/2 concern deliberately kept out of the
+  # fast per-PR gate. That trade-off doesn't apply here -- there's no other
+  # tier picking up cross-platform coverage -- so all three OSes are in the
+  # required gate directly. Coverage is collected on just the ubuntu leg to
+  # avoid three redundant/conflicting Codecov uploads for the same run.
   tests-cli:
     name: Unit tests
+    runs-on: ${{ matrix.os }}
 
-    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout repository
@@ -48,12 +60,18 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
+      - name: Run tests
+        if: matrix.os != 'ubuntu-latest'
+        run: cargo test --bins --tests
+
       - name: Install cargo-llvm-cov
+        if: matrix.os == 'ubuntu-latest'
         uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
           tool: cargo-llvm-cov
 
       - name: Generate code coverage
+        if: matrix.os == 'ubuntu-latest'
         env:
           RUST_BACKTRACE: "1"
         run: cargo llvm-cov --bins --tests --lcov --output-path lcov.info
@@ -61,7 +79,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_ORG_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,26 +69,6 @@ jobs:
           verbose: true
           files: ./lcov.info
 
-  doc-tests:
-    name: Doc tests
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
-        with:
-          toolchain: stable
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
-
-      - name: Run doc tests
-        run: cargo test --doc
-
   docs-private:
     name: Internal docs build (private items, warnings denied)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,26 +1,20 @@
 # Enforce Tier 1A support tier.
 
-# See tier-1b.yml for a more complete suite of tests.
-# You can add the label "check-release" to any PR to invoke that
-# larger set of tests.
-
-# If you change the supported platforms in this workflow, please also
-# update docs/support-tiers.md to match the changes you're making.
+# See beta-preflight.yml for the Rust-beta preflight variant.
 
 # Fork-PR trust is handled by GitHub, not by this workflow: the repository's
 # "Fork pull request workflows from outside collaborators" Actions setting holds
 # a fork PR's workflows until a maintainer approves them, so by the time this
 # suite runs it is already authorized. Same-repo branches (which require write
 # access to push) always run. Secrets are still never exposed to fork PRs, so
-# the Codecov upload steps below additionally gate on the PR originating from
+# the Codecov upload step below additionally gates on the PR originating from
 # this repository.
 
 name: Tier 1A
 
 on:
   workflow_dispatch:
-  # Daily full-suite run against main (nightly). Scheduled runs use the default
-  # branch (main). See docs/support-tiers.md.
+  # Daily full-suite run against main (nightly).
   schedule:
     - cron: '0 8 * * *'
   pull_request:
@@ -36,41 +30,8 @@ on:
       - '*-rc*'
 
 jobs:
-  get-features:
-    name: Get features
-    runs-on: ubuntu-latest
-    outputs:
-      features: ${{ steps.get-features.outputs.features }}
-      rust-native-features: ${{ steps.get-features.outputs.rust-native-features }}
-      openssl-features: ${{ steps.get-features.outputs.openssl-features }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
-        with:
-          toolchain: stable
-
-      - name: Get all features
-        id: get-features
-        run: |
-          # Experimental (`unstable_`) features are deliberately excluded from
-          # the required suite: they sit outside the SDK's normal support
-          # commitments and must not gate main or the release branches. They are
-          # exercised separately by the non-blocking experimental-features.yml.
-          # See docs/experimental-features.md.
-          FEATURES=$(cargo metadata --format-version=1 | jq -r '[.packages[] | select(.name=="c2pa") | .features | keys | map(select(. != "default" and (startswith("unstable_") | not))) | .[]] | unique | join(" ")')
-
-          RUST_NATIVE_FEATURES=$(echo $FEATURES | sed 's/openssl//g')
-          OPENSSL_FEATURES=$(echo $FEATURES | sed 's/rust_native_crypto//g')
-          echo "features=$FEATURES" >> "$GITHUB_OUTPUT"
-          echo "rust-native-features=$RUST_NATIVE_FEATURES" >> "$GITHUB_OUTPUT"
-          echo "openssl-features=$OPENSSL_FEATURES" >> "$GITHUB_OUTPUT"
-
   tests-cli:
     name: Unit tests
-    needs: get-features
 
     runs-on: ubuntu-latest
 
@@ -95,9 +56,7 @@ jobs:
       - name: Generate code coverage
         env:
           RUST_BACKTRACE: "1"
-          FEATURES: ${{needs.get-features.outputs.openssl-features}}
-        run: |
-          cargo llvm-cov --bins --features "$FEATURES" --lcov --output-path lcov.info
+        run: cargo llvm-cov --bins --lcov --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
@@ -108,4 +67,188 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: true
           verbose: true
-          files: ./lcov-openssl.info,./lcov-rust_native_crypto.info
+          files: ./lcov.info
+
+  doc-tests:
+    name: Doc tests
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run doc tests
+        run: cargo test --doc
+
+  docs-private:
+    name: Internal docs build (private items, warnings denied)
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      # c2patool doesn't publish to docs.rs (it's a binary, no public-API
+      # surface), so this checks the internal docs contributors actually
+      # read locally -- including private items -- build cleanly instead.
+      - name: Build internal docs
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+        run: cargo doc --document-private-items --no-deps
+
+  cargo-check:
+    name: Default features build
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: "`cargo check` with default features"
+        run: cargo check
+
+  cargo-lock:
+    name: Cargo.lock is up to date
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+
+      - name: Check that Cargo.lock is up to date
+        run: cargo check --locked
+
+  tests-wasi:
+    name: Unit tests (WASI)
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+        # Nightly required for testing until this issue is resolved:
+        # wasip2 target should not conditionally feature gate stdlib APIs rust-lang/rust#130323 https://github.com/rust-lang/rust/issues/130323
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: nightly-2026-01-16
+
+      - name: Install wasmtime
+        run: |
+          # Pinned to v47.0.3: v48.0.0 sends malformed wasi-http requests that
+          # some servers (e.g. GitHub Pages) answer with 400 Bad Request instead
+          # of reaching the real response, breaking did:web resolution tests.
+          curl https://wasmtime.dev/install.sh -sSf | bash -s -- --version v47.0.3
+          echo "$HOME/.wasmtime/bin" >> $GITHUB_PATH
+
+      - name: Install clang
+        run: |
+          # The runner image ships with Microsoft's apt repositories, which
+          # intermittently serve an invalid InRelease file and make
+          # `apt-get update` fail. We don't need them here, so remove them first.
+          sudo rm -f /etc/apt/sources.list.d/microsoft-prod.list \
+                     /etc/apt/sources.list.d/azure-cli.list \
+                     /etc/apt/sources.list.d/azure-cli.sources
+          sudo apt-get update
+          sudo apt-get install -y clang
+
+      - name: Add wasm32-wasip2 target
+        run: rustup target add --toolchain nightly-2026-01-16 wasm32-wasip2
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run WASI tests
+        env:
+          CARGO_TARGET_WASM32_WASIP2_RUNNER: "wasmtime -S cli -S http --dir . --env GITHUB_ACTIONS=${GITHUB_ACTIONS}"
+          CC: clang
+          RUST_MIN_STACK: 16777216
+        run: |
+          cargo +nightly-2026-01-16 test --target wasm32-wasip2 -- --no-capture
+
+  clippy_check:
+    name: Clippy
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: stable
+          components: clippy
+
+      - name: Cache Rust dependencies
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Run Clippy
+        run: cargo clippy --all-targets -- -Dwarnings
+
+  cargo_fmt:
+    name: Enforce Rust code format
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
+        with:
+          toolchain: nightly-2026-01-16
+          components: rustfmt
+
+      - name: Check format
+        run: cargo +nightly-2026-01-16 fmt --all -- --check
+
+  cargo-deny:
+    name: License / vulnerability audit
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Audit crate dependencies
+        uses: EmbarkStudios/cargo-deny-action@bb137d7af7e4fb67e5f82a49c4fce4fad40782fe # v2.0.20
+        with:
+          command: check advisories bans licenses sources

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_ORG_TOKEN }}
           fail_ci_if_error: true
           verbose: true
           files: ./lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,9 +35,11 @@ jobs:
   # the SDK crate this repo split from, where cross-platform testing is a
   # separate, more-expensive Tier 1B/2 concern deliberately kept out of the
   # fast per-PR gate. That trade-off doesn't apply here -- there's no other
-  # tier picking up cross-platform coverage -- so all three OSes are in the
-  # required gate directly. Coverage is collected on just the ubuntu leg to
-  # avoid three redundant/conflicting Codecov uploads for the same run.
+  # tier picking up cross-platform or MSRV coverage -- so both are in the
+  # required gate directly (matching how tier-1b.yml combines `os` and
+  # `rust_version: [stable, 1.88.0]` upstream). Coverage is collected on just
+  # the ubuntu+stable leg to avoid six redundant/conflicting Codecov uploads
+  # for the same run.
   tests-cli:
     name: Unit tests
     runs-on: ${{ matrix.os }}
@@ -46,6 +48,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        rust_version: [stable, "1.88.0"] # keep in sync with Cargo.toml's rust-version
 
     steps:
       - name: Checkout repository
@@ -54,24 +57,24 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master@2026-06-30
         with:
-          toolchain: stable
+          toolchain: ${{ matrix.rust_version }}
           components: llvm-tools-preview
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
       - name: Run tests
-        if: matrix.os != 'ubuntu-latest'
+        if: matrix.os != 'ubuntu-latest' || matrix.rust_version != 'stable'
         run: cargo test --bins --tests
 
       - name: Install cargo-llvm-cov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.rust_version == 'stable'
         uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
         with:
           tool: cargo-llvm-cov
 
       - name: Generate code coverage
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && matrix.rust_version == 'stable'
         env:
           RUST_BACKTRACE: "1"
         run: cargo llvm-cov --bins --tests --lcov --output-path lcov.info
@@ -79,7 +82,7 @@ jobs:
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.
       - name: Upload code coverage results
-        if: matrix.os == 'ubuntu-latest' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: matrix.os == 'ubuntu-latest' && matrix.rust_version == 'stable' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_ORG_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Generate code coverage
         env:
           RUST_BACKTRACE: "1"
-        run: cargo llvm-cov --bins --lcov --output-path lcov.info
+        run: cargo llvm-cov --bins --tests --lcov --output-path lcov.info
 
       # Tokens aren't available for PRs originating from forks,
       # so we don't attempt to upload code coverage in that case.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -503,7 +509,7 @@ dependencies = [
  "png_pong",
  "quick-xml",
  "rand 0.10.2",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "range-set",
  "rasn",
  "rasn-cms",
@@ -557,10 +563,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea8b0035cb7a2d51e0664be21e1f5635d6cb572256beab9a7356b6ca3e3b6743"
 dependencies = [
  "const-hex",
+ "ecdsa",
+ "ed25519-dalek",
  "getrandom 0.2.17",
  "openssl",
+ "p256",
+ "p384",
+ "p521",
+ "pkcs1",
  "pkcs8",
+ "rand 0.8.8",
+ "rsa",
  "serde",
+ "sha2 0.11.0",
  "spki",
  "thiserror 2.0.20",
  "zeroize",
@@ -892,6 +907,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1076,7 +1103,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
+ "const-oid 0.9.6",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1123,6 +1152,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der 0.7.10",
+ "digest 0.10.7",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
 name = "ed25519"
 version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1153,6 +1196,26 @@ name = "either"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest 0.10.7",
+ "ff",
+ "generic-array",
+ "group",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encoding_rs"
@@ -1263,6 +1326,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]
@@ -1417,6 +1490,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1475,6 +1549,17 @@ name = "glob"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
+
+[[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
 
 [[package]]
 name = "h2"
@@ -1559,6 +1644,15 @@ name = "hex_fmt"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b07f60793ff0a4d9cef0f18e63b5357e06209987153a64648c972c1e5aff336f"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "http"
@@ -2078,12 +2172,21 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2333,6 +2436,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.8",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2348,12 +2467,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -2431,6 +2561,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "p521"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
+dependencies = [
+ "base16ct",
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2500,6 +2668,17 @@ name = "pix"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a054a84d1ff0dc456386e5fc081e099e6855ddcc8913dc9349c294d47d76bd4"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der 0.7.10",
+ "pkcs8",
+ "spki",
+]
 
 [[package]]
 name = "pkcs8"
@@ -2613,6 +2792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2654,7 +2842,7 @@ dependencies = [
  "bitflags 2.13.1",
  "num-traits",
  "rand 0.9.5",
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "unarray",
@@ -2766,11 +2954,22 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e058c7de0b26af77780c769414d6257830bb240f3c38477dbc2c16e5f54d6d4c"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -2783,6 +2982,16 @@ dependencies = [
  "chacha20",
  "getrandom 0.4.3",
  "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3052,6 +3261,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "riff"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3069,6 +3288,27 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid 0.9.6",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sha2 0.10.9",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3194,6 +3434,20 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der 0.7.10",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "security-framework"
@@ -3492,6 +3746,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,9 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "aes"
-version = "0.9.3"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35f0f96ce78e38c3dc6d8948aa8163d06385be74000f3c7a95bf1eef35d3ea32"
+checksum = "f1fc76eaeac4c9164506c466d4ffdd8ec9d0c5bf57ee97177c4d8eceb3a0e138"
 dependencies = [
  "cipher",
  "cpubits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ documentation = "https://opensource.contentauthenticity.org/docs/c2patool"
 readme = "README.md"
 keywords = ["c2pa", "xmp", "metadata"]
 edition = "2018"
+rust-version = "1.88.0"
 homepage = "https://contentauthenticity.org"
 repository = "https://github.com/contentauth/c2patool"
 # edition 2018 defaults to resolver "1", which unifies a dependency's

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,12 @@ keywords = ["c2pa", "xmp", "metadata"]
 edition = "2018"
 homepage = "https://contentauthenticity.org"
 repository = "https://github.com/contentauth/c2patool"
+# edition 2018 defaults to resolver "1", which unifies a dependency's
+# features across ALL targets in one pass -- the target-conditional `c2pa`
+# feature split below (openssl vs. rust_native_crypto, wasi vs. everything
+# else) needs "2" or later to actually resolve per-target instead of
+# enabling both backends at once.
+resolver = "3"
 
 [features]
 default = ["networking"]
@@ -24,20 +30,6 @@ networking = [
 [dependencies]
 anyhow = "1.0"
 atree = "0.5.4"
-# Tracks c2pa-rs's `main` branch directly (see docs/release-process.md,
-# "Tracking c2pa-rs main") so integration breaks against upstream's
-# in-development code surface immediately rather than only once a new
-# `c2pa` version publishes. A scheduled workflow keeps Cargo.lock fresh
-# against this branch. `stable` (and any `v0.*` line) uses a real crates.io
-# version instead -- crates.io requires every dependency to resolve to a
-# published version, so this branch is never itself published.
-c2pa = { git = "https://github.com/contentauth/c2pa-rs", branch = "main", features = [
-    "openssl",
-    "fetch_remote_manifests",
-    "file_io",
-    "add_thumbnails",
-    "pdf",
-] }
 clap = { version = "4.6.1", features = ["derive", "env", "string"] }
 env_logger = "0.11.10"
 glob = "0.3.3"
@@ -51,7 +43,27 @@ pem = "4.0.0"
 url = "2.5.8"
 etcetera = "0.11.0"
 
+# Tracks c2pa-rs's `main` branch directly (see docs/release-process.md,
+# "Tracking c2pa-rs main") so integration breaks against upstream's
+# in-development code surface immediately rather than only once a new
+# `c2pa` version publishes. A scheduled workflow keeps Cargo.lock fresh
+# against this branch. `stable` (and any `v0.*` line) uses a real crates.io
+# version instead -- crates.io requires every dependency to resolve to a
+# published version, so this branch is never itself published.
+#
+# The crypto backend feature is target-conditional, split below: `openssl`
+# doesn't compile for wasm32 (c2pa-rs's own openssl dependency is itself
+# gated to `not(target_arch = "wasm32")`), so the wasi target needs
+# `rust_native_crypto` instead. Keep the two feature lists (everything
+# except the backend name) in sync by hand.
 [target.'cfg(not(target_os = "wasi"))'.dependencies]
+c2pa = { git = "https://github.com/contentauth/c2pa-rs", branch = "main", features = [
+    "openssl",
+    "fetch_remote_manifests",
+    "file_io",
+    "add_thumbnails",
+    "pdf",
+] }
 reqwest = { version = "0.12.28", features = ["blocking"] }
 tokio = { version = "1.52.3", features = ["rt", "rt-multi-thread"] }
 
@@ -62,6 +74,13 @@ windows-sys = { version = "0.59", features = [
 ] }
 
 [target.'cfg(target_os = "wasi")'.dependencies]
+c2pa = { git = "https://github.com/contentauth/c2pa-rs", branch = "main", default-features = false, features = [
+    "rust_native_crypto",
+    "fetch_remote_manifests",
+    "file_io",
+    "add_thumbnails",
+    "pdf",
+] }
 wasi = "0.14"
 wstd = "0.5"
 

--- a/deny.toml
+++ b/deny.toml
@@ -50,4 +50,7 @@ license-files = [
 unknown-registry = "deny"
 unknown-git = "deny"
 allow-registry = ["https://github.com/rust-lang/crates.io-index"]
-allow-git = []
+# main's own c2pa dependency (see docs/release-process.md, "Tracking
+# c2pa-rs main") -- intentional there, never present on a release branch
+# (check-no-patch-deps.yml enforces that separately).
+allow-git = ["https://github.com/contentauth/c2pa-rs"]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1577,7 +1577,7 @@ pub mod tests {
 
     #[test]
     fn apply_trust_sidecars_reads_official_pem() {
-        const SAMPLE_ANCHOR_PEM: &str = include_str!("../../cli/tests/fixtures/trust/anchors.pem");
+        const SAMPLE_ANCHOR_PEM: &str = include_str!("../tests/fixtures/trust/anchors.pem");
         let tmp = tempdirectory().unwrap();
         let settings_path = tmp.path().join("c2pa.toml");
         write(

--- a/src/main.rs
+++ b/src/main.rs
@@ -646,7 +646,13 @@ fn atomic_write_file(dest: &Path, contents: &[u8]) -> Result<()> {
         .file_name()
         .and_then(|s| s.to_str())
         .unwrap_or("c2pa-trust");
-    let tmp = parent.join(format!(".{stem}.{}.tmp", std::process::id()));
+    // A nanosecond timestamp, not `std::process::id()`: WASI has no process-ID
+    // concept, and `std::process::id()` panics there rather than erroring.
+    let unique = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_nanos())
+        .unwrap_or_default();
+    let tmp = parent.join(format!(".{stem}.{unique}.tmp"));
     {
         let mut f = File::create(&tmp)?;
         f.write_all(contents)?;


### PR DESCRIPTION
Restores the CI jobs dropped during the repo split (which only carried a `tests-cli` slice), adapted for a single binary crate with no workspace and no backend-feature matrix. See the commit message for the full kept/dropped/new breakdown. Adds one new job not present in c2pa-rs: `docs-private` (`cargo doc --document-private-items`, warnings denied) -- c2patool doesn't publish to docs.rs, but internal docs should still build cleanly.

**Depends on the 'auto-track c2pa-rs main' PR** -- `main`'s `Cargo.toml` currently depends on an unpublished `c2pa` version (`0.91.0-dev`), so none of this CI can actually run green until that's merged too.

Part of restoring c2patool's post-cutover release infrastructure.