### PR TITLE
ci: Version-control GitHub labels via labels.yml

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,105 @@
+# Version-controlled GitHub labels, synced by the labels.yml workflow via
+# crazy-max/ghaction-github-labeler. Add long-lasting labels here rather
+# than creating them by hand in the GitHub UI.
+#
+# NOTE: This file intentionally lists only the labels the release process
+# depends on, plus general triage labels. Per-line backport labels
+# (backport-v0.<N>) can be created manually on demand in the rare event that
+# a security or other backport is created for a release train that is
+# considered retired.
+
+- name: release
+  color: "0e8a16"
+  description: "release-plz release PR; runs the required Tier 1A suite"
+
+- name: awaiting-cla-signature
+  color: "d93f0b"
+  description: "Third-party PR is blocked until the author signs the Adobe CLA"
+
+- name: check-release
+  color: "1d76db"
+  description: "Force the beta-preflight suite on this PR"
+
+- name: backport-stable
+  color: "5319e7"
+  description: "Cherry-pick this merged main PR onto the stable release line"
+
+- name: do-not-backport
+  color: "6a737d"
+  description: "Deliberately not backported onto stable (e.g. incompatible behavior change)"
+
+- name: release-train
+  color: "fbca04"
+  description: "Tracking issue for an active breaking-change release train bake"
+
+- name: upstream-first-verified
+  color: "0e8a16"
+  description: "Attests an adapted cherry-pick is already on main (exempts the upstream-first check)"
+
+- name: reconciliation
+  color: "d93f0b"
+  description: "A release branch has commits missing from main (upstream-first violation)"
+
+- name: accepted
+  color: "0e8a16"
+  description: "Triaged and accepted for work"
+
+- name: bug
+  color: "b60205"
+  description: "Something isn't working"
+
+- name: feature
+  color: "fbca04"
+  description: "New capability or enhancement"
+
+- name: task
+  color: "1d76db"
+  description: "General work item or chore"
+
+- name: "status: todo"
+  color: "ededed"
+  description: "Not yet started"
+
+- name: "status: wip"
+  color: "ededed"
+  description: "Work in progress"
+
+- name: "status: in progress"
+  color: "ededed"
+  description: "Actively being worked on"
+
+- name: "status: in test"
+  color: "ededed"
+  description: "Undergoing testing"
+
+- name: "status: not prioritized"
+  color: "ededed"
+  description: "Not yet prioritized for work"
+
+- name: "status: blocked"
+  color: "ededed"
+  description: "Blocked on another issue or dependency"
+
+- name: "status: api review"
+  color: "ededed"
+  description: "Awaiting API review"
+
+- name: "status: code review"
+  color: "ededed"
+  description: "Awaiting code review"
+
+- name: "status: design review"
+  color: "ededed"
+  description: "Awaiting design review"
+
+- name: "status: code complete"
+  color: "ededed"
+  description: "Code complete, pending remaining checks"
+
+- name: "status: ready"
+  color: "ededed"
+  description: "Ready to be worked on"
+
+- name: "status: done"
+  color: "ededed"
+  description: "Completed"

--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,0 +1,34 @@
+name: Sync labels
+
+# Keeps the repository's GitHub labels in sync with .github/labels.yml so the
+# labels the release process depends on are version-controlled rather than
+# hand-managed in the UI.
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - .github/labels.yml
+      - .github/workflows/labels.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  labeler:
+    name: Sync labels from .github/labels.yml
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Sync labels
+        uses: crazy-max/ghaction-github-labeler@24d110aa46a59976b8a7f35518cb7f14f434c916 # v5
+        with:
+          yaml_file: .github/labels.yml
+          # Do not delete labels that are not listed here (e.g. issue-status
+          # labels managed elsewhere, or on-demand backport-v0.<N> labels).
+          skip_delete: true


### PR DESCRIPTION
Ports c2pa-rs's label-sync mechanism so the labels the release process depends on (`release`, `backport-stable`, `release-train`, `upstream-first-verified`, `reconciliation`, `check-release`) are version-controlled instead of hand-created in the UI. Once merged and this workflow runs (push to `main`, or `workflow_dispatch`), it creates/updates those labels automatically -- replacing the manual label-creation step previously called out in #310's checklist.

**Dropped** two labels that reference infrastructure c2patool doesn't have: `safe to test` (superseded by GitHub's native fork-PR-approval, which this repo already uses) and `canary` (cross-repo canary drift detection -- no extracted crates here). Adjusted `release`/`check-release` descriptions to reference c2patool's actual suites (Tier 1A / beta-preflight) instead of c2pa-rs's Tier 1A+1B+2. Kept the general triage labels (bug, feature, task, status: *) for consistency with upstream.

Requested to land ahead of #310, which references several of these labels.