### PR TITLE
ci: Add commit-lint enforcement for PR titles

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,51 @@
+# If updating this file, please also review `docs/release-process.md`,
+# `CONTRIBUTING.md`, and `.github/workflows/pr_title.yml` and update the
+# summary of these rules in those files accordingly.
+
+rules:
+  # Body may be empty
+  body-empty:
+    level: ignore
+
+  # Description must not be empty
+  description-empty:
+    level: error
+
+  # Description must start with a capital letter and must not end with a period or space
+  description-format:
+    level: error
+    format: ^[A-Z0-9].*[^. ]$
+
+  # Description should be <70 chars
+  description-max-length:
+    level: warning
+    length: 70
+
+  # Scope is not allowed. Unlike c2pa-rs (a monorepo with several crates
+  # to disambiguate), c2patool is a single crate, so a scope would never
+  # carry useful information.
+  scope:
+    level: error
+    optional: false
+    options: []
+
+  # Subject line should exist
+  subject-empty:
+    level: error
+
+  # Type must be one of these options
+  type:
+    level: error
+    options:
+      - build
+      - chore
+      - ci
+      - docs
+      - feat
+      - fix
+      - perf
+      - refactor
+      - revert
+      - style
+      - test
+      - update

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -34,7 +34,7 @@ jobs:
           # `type` describes the nature of changes you are making. This project
           # requires the type to be one of these exact names:
           #
-          #    * feat (will cause a minor version bump)
+          #    * feat
           #    * fix
           #    * chore (will be omitted from changelog)
           #    * docs

--- a/.github/workflows/pr_title.yml
+++ b/.github/workflows/pr_title.yml
@@ -1,0 +1,114 @@
+name: PR title
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  title_cc_validation:
+    name: Conventional commits validation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      # If changing this, please also see `.commitlintrc.yml`,
+      # `CONTRIBUTING.md`, and `docs/release-process.md`.
+
+      - name: Check PR title
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          # If this step fails, please expand this step for more information.
+          #
+          # You will need to revise this pull request's title to
+          # match the "summary" (first) line of a Conventional Commit message.
+          # This enables us to automatically generate a meaningful changelog.
+          #
+          # The summary line (and thus the PR title) must have this exact format
+          # (including punctuation):
+          #
+          #     type: description
+          #
+          # `type` describes the nature of changes you are making. This project
+          # requires the type to be one of these exact names:
+          #
+          #    * feat (will cause a minor version bump)
+          #    * fix
+          #    * chore (will be omitted from changelog)
+          #    * docs
+          #    * build, ci, perf, refactor, revert, style, test
+          #    * update (used by Dependabot)
+          #
+          # NOTE: Conventional Commits also defines a `(scope)` parameter
+          # which can define a sub-area within the project where the change was
+          # made. This project is configured to disallow the use of `scope`,
+          # since c2patool is a single crate and a scope would never carry
+          # useful information.
+          #
+          # `description` is a short human-readable summary of the changes being made.
+          #
+          # This project enforces a few rules over and above the Conventional
+          # Commits definition of `description`:
+          #
+          #    * The `description` must be non-empty.
+          #    * The `description` must start with a capital letter or number.
+          #      (Do not start `description` with a lower-case word.)
+          #    * The `description` must not end with a period.
+          #
+          # This project does not currently enforce the following items, but
+          # we ask that you observe the following preferences in `description`:
+          #
+          #    * The entire description should be written and capitalized as
+          #      an English-language sentence, except (as noted earlier) that
+          #      the trailing period must be omitted.
+          #    * Any acronyms such as JSON or YAML should be capitalized as per
+          #      common usage in English-language sentences.
+          #
+          # After you edit the PR title, this task will run again and the
+          # warning should go away if you have made acceptable changes.
+          #
+          # For more information on Conventional Commits, please see:
+          #
+          #    https://www.conventionalcommits.org/en/v1.0.0/
+          #
+          # ------------ (end of message) ------------
+
+          if echo "$PR_TITLE" | grep -E '^chore: release '; then
+            echo "Exception / OK: chore release pattern"
+            exit 0;
+          fi
+
+          if echo "$PR_TITLE" | grep -E '^chore: release$'; then
+            echo "Exception / OK: chore release pattern"
+            exit 0;
+          fi
+
+          if echo "$PR_TITLE" | grep -E '^chore: bump '; then
+            echo "Exception / OK: Dependabot update pattern"
+            exit 0;
+          fi
+
+          if echo "$PR_TITLE" | grep -E '^update: update '; then
+            echo "Exception / OK: Dependabot update pattern"
+            exit 0;
+          fi
+
+          if echo "$PR_TITLE" | grep -E '^update: bump '; then
+            echo "Exception / OK: Dependabot update pattern"
+            exit 0;
+          fi
+
+          echo "Installing commitlint-rs. Please wait 30-40 seconds ..."
+          cargo install --quiet commitlint-rs
+          set -e
+
+          echo
+          echo
+          echo --- commitlint results for PR title \"$PR_TITLE\" ---
+          echo
+
+          echo "$PR_TITLE" | commitlint -g .commitlintrc.yml
+
+          echo "✅ PR title matches all enforced rules."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,22 +73,23 @@ For the full model, see the [release process](docs/release-process.md).
 
 ### Pull request titles
 
-Titles of pull requests that target a long-lived branch such as _main_ or a release-specific branch should follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification). The repository's [commit lint rules](https://github.com/contentauth/c2pa-rs/blob/main/.commitlintrc.yml) require that the first word of the pull request title must be one of the following:
+Titles of pull requests that target a long-lived branch such as _main_ or a release-specific branch should follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#specification). The repository's [commit lint rules](.commitlintrc.yml) require that the first word of the pull request title must be one of the following:
 
-- `fix`
 - `feat`
+- `fix`
 - `chore`
-- `update`
-- `doc`
+- `docs`
+- `build`, `ci`, `perf`, `refactor`, `revert`, `style`, `test`
+- `update` (used by Dependabot)
 
-Optionally, but preferred, a scope can be added in parentheses after the type. The scope should be the name of the module or component that the commit affects. For example, `feat(api): Introduce a new API to validate 1.0 claims`.
+Unlike [c2pa-rs](https://github.com/contentauth/c2pa-rs/blob/main/CONTRIBUTING.md), this repository does **not** allow a `(scope)` after the type: c2patool is a single crate, so a scope would never carry useful information. See [Commit lint used for PR title enforcement](docs/release-process.md#commit-lint-used-for-pr-title-enforcement) for the full rules.
 
 If more detail is warranted, add a blank line and then continue with sentences (these sentences should be punctuated as such) and paragraphs as needed to provide that detail. There is no need to word-wrap this message.
 
 For example:
 
 ```text
-feat(api): Introduce a new API to validate 1.0 claims
+feat: Introduce a new API to validate 1.0 claims
 
 Repurpose existing v2 API for 0.8 compatibility (read: no validation) mode.
 ```

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -162,7 +162,28 @@ The first build (`-rc.1`) is cut automatically when the train is cut. A maintain
 
 See [`docs/support-tiers.md`](support-tiers.md) for the build configurations Tier 1A actually covers.
 
-Commit-lint enforcement of PR titles (as c2pa-rs does via `pr_title.yml`/`.commitlintrc.yml`) is not yet ported to this repo -- follow-up work, not covered here.
+## Commit lint used for PR title enforcement
+
+Because `release-plz` uses [Conventional Commit syntax](https://www.conventionalcommits.org/en/v1.0.0/#summary) to generate changelogs, all commits to long-lived branches must follow it. We [squash-merge](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/configuring-commit-squashing-for-pull-requests) PRs, and [`pr_title.yml`](https://github.com/contentauth/c2patool/blob/main/.github/workflows/pr_title.yml) checks that each PR title conforms, as configured by [`.commitlintrc.yml`](https://github.com/contentauth/c2patool/blob/main/.commitlintrc.yml) (the definitive specification).
+
+A quick, non-authoritative summary: the PR title must have this exact format:
+
+```
+type: description
+```
+
+The `type` must be one of (bold = preferred in most cases):
+
+* **`feat`**: a new feature. Use a `!` immediately before the `:` to signal an API breaking change (which queues for the next train).
+* **`fix`**: a bug fix.
+* **`chore`**: maintenance; does not trigger a release PR and is omitted from the changelog.
+* **`docs`**: documentation.
+* `build`, `ci`, `perf`, `refactor`, `revert`, `style`, `test`, `update` (the last used by Dependabot).
+
+Unlike c2pa-rs, `scope` is not allowed here: c2patool is a single crate, so `type(scope): description` would never carry information that `type: description` doesn't already. `description` is a short sentence, capitalized, no trailing period, preferably under 70 characters.
+
+> [!NOTE]
+> If these rules change, keep [`.github/workflows/pr_title.yml`](https://github.com/contentauth/c2patool/blob/main/.github/workflows/pr_title.yml) and [`.commitlintrc.yml`](https://github.com/contentauth/c2patool/blob/main/.commitlintrc.yml) in sync.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- Add `.commitlintrc.yml` and `.github/workflows/pr_title.yml`, ported from [c2pa-rs's](https://github.com/contentauth/c2pa-rs/blob/main/.commitlintrc.yml) commit-lint setup.
- Unlike c2pa-rs, `scope` is disallowed entirely (`optional: false`, `options: []`), following [adobe/xmp-toolkit-rs](https://github.com/adobe/xmp-toolkit-rs/blob/main/.commitlintrc.yml)'s no-scope pattern — c2patool is a single crate, so a scope would never disambiguate anything the way it does in c2pa-rs's multi-crate monorepo.
- The allowed `type` list matches c2pa-rs's (`feat`, `fix`, `chore`, `docs`, `build`, `ci`, `perf`, `refactor`, `revert`, `style`, `test`, `update`), since this repo's actual commit history (inherited from the c2pa-rs monorepo split) already uses most of these.
- Update `docs/release-process.md` with a "Commit lint used for PR title enforcement" section (mirroring c2pa-rs's, minus scope), replacing the stale note that flagged this as not-yet-ported follow-up work.
- Update `CONTRIBUTING.md`'s "Pull request titles" section, which was still copied from c2pa-rs and described scope as optional-but-preferred — now points at this repo's own `.commitlintrc.yml` and states scope is disallowed.

## Test plan
- [x] Installed `commitlint-rs` locally and validated `.commitlintrc.yml` against sample titles: a valid no-scope title passes; a scoped title, a lowercase description, an unknown type, and a trailing period each correctly fail.
- [x] Verified the workflow's `chore: release`/`update: bump`/`update: update` exception patterns match the title shapes release-plz and Dependabot actually produce.
- [x] Ran `actionlint` against the new workflow (only a pre-existing-style shellcheck info note, matching what `ci.yml` already has).

🤖 Generated with [Claude Code](https://claude.com/claude-code)