### PR TITLE
chore: Enable Dependabot version updates, excluding c2pa

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,25 +1,29 @@
-# TEMPORARILY DISABLED -- restore by uncommenting once the new repo's
-# initial setup (secrets, branch protection, etc.) is settled.
-#
 # Please see the documentation for all configuration options:
 # https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
-# version: 2
-# updates:
-#   - package-ecosystem: "cargo"
-#     directory: "/"
-#     schedule:
-#       interval: "daily"
-#     commit-message:
-#       prefix: "update"
-#     cooldown:
-#       default-days: 7
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "update"
+    cooldown:
+      default-days: 7
+    # `c2pa` has its own express lane instead: on `main` it's a git dependency
+    # tracked by track-c2pa-rs-main.yml, and on `stable` a new release is
+    # picked up immediately by c2pa-release-bump.yml (see
+    # docs/release-process.md). Dependabot wouldn't offer version updates for
+    # the git dependency anyway, but this makes the exclusion explicit.
+    ignore:
+      - dependency-name: "c2pa"
 
-#   - package-ecosystem: "github-actions"
-#     directory: "/"
-#     schedule:
-#       interval: "weekly"
-#     commit-message:
-#       prefix: "chore"
-#     cooldown:
-#       default-days: 7
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Re-enables `.github/dependabot.yml` (cargo + github-actions ecosystems), which was fully commented out pending "the new repo's initial setup (secrets, branch protection, etc.)". Verified that's now settled: `main` and `stable` both have active rulesets requiring PRs + status checks, and the org secrets (`RELEASE_PLZ_ORG_TOKEN`, `CROSS_ORG_PR_TOKEN`, `CRATES_IO_ORG_TOKEN`) already exist.
- Excludes `c2pa` via an `ignore` rule on the cargo entry, since it now has its own express lane instead: [`track-c2pa-rs-main.yml`](.github/workflows/track-c2pa-rs-main.yml) on `main`, [`c2pa-release-bump.yml`](.github/workflows/c2pa-release-bump.yml) on `stable` (from #316).

## Note

This was originally pushed as a follow-up commit on #316, but that PR had already been merged by the time it landed, so it never made it in. Recreated here as its own PR.

## Test plan

- [ ] Confirm Dependabot opens PRs for other cargo/GitHub Actions dependencies but never for `c2pa`

🤖 Generated with [Claude Code](https://claude.com/claude-code)